### PR TITLE
Add gangway image

### DIFF
--- a/caasp-gangway-image/Makefile
+++ b/caasp-gangway-image/Makefile
@@ -1,0 +1,1 @@
+../.images.Makefile

--- a/caasp-gangway-image/_service
+++ b/caasp-gangway-image/_service
@@ -1,0 +1,8 @@
+<services>
+    <service name="replace_using_package_version" mode="buildtime">
+        <param name="file">caasp-gangway-image.kiwi</param>
+        <param name="regex">%%PKG_VERSION%%</param>
+        <param name="parse-version">patch</param>
+        <param name="package">gangway</param>
+    </service>
+</services>

--- a/caasp-gangway-image/caasp-gangway-image.kiwi
+++ b/caasp-gangway-image/caasp-gangway-image.kiwi
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- OBS-AddTag: caasp/v4/gangway:%%PKG_VERSION%%-rev<VERSION> caasp/v4/gangway:%%PKG_VERSION%%-rev<VERSION>-build<RELEASE> caasp/v4/gangway:beta -->
+
+<!--
+    PLEASE, REMOVE BETA TAG ON RELEASE
+-->
+<image schemaversion="6.9" name="caasp-gangway-image">
+  <description type="system">
+    <author>SUSE Containers Team</author>
+    <contact>containers@suse.com</contact>
+    <specification>Image containing gangway for CaaSP</specification>
+  </description>
+  <preferences>
+    <type
+      image="docker"
+      derived_from="obsrepositories:/suse/sle15#15.1">
+      <containerconfig
+        name="caasp/v4/gangway"
+        tag="%%PKG_VERSION%%"
+        maintainer="SUSE Containers Team &lt;containers@suse.com&gt;">
+        <entrypoint execute="/usr/bin/gangway"/>
+        <subcommand clear="true"/>
+        <labels>
+          <label name="com.suse.caasp.v4.description" value="Image containing gangway for CaaSP"/>
+          <label name="com.suse.caasp.v4.reference" value="caasp/v4/gangway:%%PKG_VERSION%%"/>
+          <label name="com.suse.caasp.v4.title" value="CaaSP gangway container"/>
+          <label name="com.suse.caasp.v4.version" value="%%PKG_VERSION%%"/>
+        </labels>
+      </containerconfig>
+    </type>
+    <version>1</version>
+    <packagemanager>zypper</packagemanager>
+    <rpm-excludedocs>true</rpm-excludedocs>
+  </preferences>
+  <repository>
+    <source path="obsrepositories:/"/>
+  </repository>
+  <packages type="image">
+    <package name="gangway"/>
+  </packages>
+</image>


### PR DESCRIPTION
Gangway is a front-end for OIDC authentication in Kubernetes clusters.  It allows the user to log in via dex and generate a KUBECONFIG to interact with the Kubernetes cluster by kubectl.

Signed-off-by: JenTing Hsiao <jenting.hsiao@suse.com>