### PR TITLE
Add conntrack-tools to hyperkube image.

### DIFF
--- a/caasp-hyperkube-image/caasp-hyperkube-image.kiwi
+++ b/caasp-hyperkube-image/caasp-hyperkube-image.kiwi
@@ -39,5 +39,6 @@
     <package name="kubernetes-common"/>
     <package name="iptables"/>
     <package name="iproute2"/>
+    <package name="conntrack-tools"/>
   </packages>
 </image>


### PR DESCRIPTION
This is needed so the `kube-proxy` containers are able to modify conntrack
entries. If the binary `conntrack` is not available in the image the following
error will be found in the `kube-proxy` containers:

```
E0703 12:59:04.940389 1 proxier.go:615] Failed to delete
kube-system/kube-dns:dns endpoint connections, error: error deleting conntrack
entries for UDP peer {10.96.0.10, 10.244.0.14}, error: error looking for path of
conntrack: exec: "conntrack": executable file not found in $PATH
```