### PR TITLE
Support for L7 network policies

### DIFF
--- a/caasp-cilium-image/caasp-cilium-image.kiwi
+++ b/caasp-cilium-image/caasp-cilium-image.kiwi
@@ -39,5 +39,7 @@
   <packages type="image">
     <package name="cilium"/>
     <package name="cilium-cni"/>
+    <package name="libboringssl0"/>
+    <package name="cilium-proxy"/>
   </packages>
 </image>


### PR DESCRIPTION
Add cilium-proxy package which provides the support for L7 network
policies.