### PR TITLE
Added caasp-dex-branding

### DIFF
--- a/caasp-caasp-dex-image/caasp-caasp-dex-image.kiwi
+++ b/caasp-caasp-dex-image/caasp-caasp-dex-image.kiwi
@@ -46,5 +46,6 @@
   </repository>
   <packages type="image">
     <package name="caasp-dex"/>
+    <package name="caasp-dex-branding"/>
   </packages> 
 </image>


### PR DESCRIPTION
Required to replace default CoreOS theme with CaaS for beta 4 release.
Signed-off-by: Chin-Ya Huang <chin-ya.huang@suse.com>

cc @jhsiaosuse @cclhsu 