### PR TITLE
Add cloud-provider-openstack image

### DIFF
--- a/caasp-cloud-provider-openstack-image/Makefile
+++ b/caasp-cloud-provider-openstack-image/Makefile
@@ -1,0 +1,1 @@
+../.images.Makefile

--- a/caasp-cloud-provider-openstack-image/_service
+++ b/caasp-cloud-provider-openstack-image/_service
@@ -1,0 +1,8 @@
+<services>
+    <service name="replace_using_package_version" mode="buildtime">
+        <param name="file">caasp-cloud-provider-openstack-image.kiwi</param>
+        <param name="regex">%%PKG_VERSION%%</param>
+        <param name="parse-version">patch</param>
+        <param name="package">cloud-provider-openstack</param>
+    </service>
+</services>

--- a/caasp-cloud-provider-openstack-image/caasp-cloud-provider-openstack-image.kiwi
+++ b/caasp-cloud-provider-openstack-image/caasp-cloud-provider-openstack-image.kiwi
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- OBS-AddTag: caasp/v4/cloud-provider-openstack:%%PKG_VERSION%%-rev<VERSION> caasp/v4/cloud-provider-openstack:%%PKG_VERSION%%-rev<VERSION>-build<RELEASE> caasp/v4/cloud-provider-openstack:beta -->
+
+<!--
+    PLEASE, REMOVE BETA TAG ON RELEASE
+-->
+<image schemaversion="6.9" name="caasp-cloud-provider-openstack-image">
+  <description type="system">
+    <author>SUSE Containers Team</author>
+    <contact>containers@suse.com</contact>
+    <specification>OpenStack cloud controller manager running on an SLES15 container guest</specification>
+  </description>
+  <preferences>
+    <type
+      image="docker"
+      derived_from="obsrepositories:/suse/sle15#15.1">
+      <containerconfig
+        name="caasp/v4/cloud-provider-openstack"
+        tag="%%PKG_VERSION%%"
+        maintainer="SUSE Containers Team &lt;containers@suse.com&gt;">
+        <entrypoint execute="/usr/bin/openstack-cloud-controller-manager"/>
+        <subcommand clear="true"/>
+        <labels>
+          <label name="com.suse.caasp.v4.description" value="OpenStack cloud controller manager running on an SLES15 container guest"/>
+          <label name="com.suse.caasp.v4.reference" value="caasp/v4/cloud-provider-openstack:%%PKG_VERSION%%"/>
+          <label name="com.suse.caasp.v4.title" value="OpenStack cloud provider container"/>
+          <label name="com.suse.caasp.v4.version" value="%%PKG_VERSION%%"/>
+        </labels>
+      </containerconfig>
+    </type>
+    <version>1</version>
+    <packagemanager>zypper</packagemanager>
+    <rpm-excludedocs>true</rpm-excludedocs>
+  </preferences>
+  <repository>
+    <source path="obsrepositories:/"/>
+  </repository>
+  <packages type="image">
+    <package name="cloud-provider-openstack"/>
+  </packages>
+</image>


### PR DESCRIPTION
Kubernetes cloud provider integration with OpenStack requires
openstack-cloud-controller-manager service which have to be added
to container registry registry.suse.de.

It is part of [Epic] Cloud Provider Integration

Issue https://github.com/SUSE/avant-garde/issues/568