### PR TITLE
CSI images

### DIFF
--- a/caasp-csi-attacher-image/_service
+++ b/caasp-csi-attacher-image/_service
@@ -1,0 +1,8 @@
+<services>
+    <service name="replace_using_package_version" mode="buildtime">
+        <param name="file">caasp-csi-attacher-image.kiwi</param>
+        <param name="regex">%%PKG_VERSION%%</param>
+        <param name="parse-version">patch</param>
+        <param name="package">external-attacher</param>
+    </service>
+</services>

--- a/caasp-csi-attacher-image/caasp-csi-attacher-image.kiwi
+++ b/caasp-csi-attacher-image/caasp-csi-attacher-image.kiwi
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- OBS-AddTag: caasp/v4/cloud-provider-openstack:%%PKG_VERSION%%-rev<VERSION> caasp/v4/cloud-provider-openstack:%%PKG_VERSION%%-rev<VERSION>-build<RELEASE> caasp/v4/cloud-provider-openstack:beta -->
+
+<!--
+    PLEASE, REMOVE BETA TAG ON RELEASE
+-->
+<image schemaversion="6.9" name="caasp-csi-attacher">
+  <description type="system">
+    <author>SUSE Containers Team</author>
+    <contact>containers@suse.com</contact>
+    <specification>caasp-csi-attacher binary on SLES15 container guest</specification>
+  </description>
+  <preferences>
+    <type
+      image="docker"
+      derived_from="obsrepositories:/suse/sle15#15.1">
+      <containerconfig
+        name="caasp/v4/caasp-csi-attacher"
+        tag="%%PKG_VERSION%%"
+        maintainer="SUSE Containers Team &lt;containers@suse.com&gt;">
+        <entrypoint execute="/usr/bin/csi-attacher"/>
+        <subcommand clear="true"/>
+        <labels>
+          <label name="com.suse.caasp.v4.description" value="caasp-csi-attacher binary on SLES15 container guest"/>
+          <label name="com.suse.caasp.v4.reference" value="caasp/v4/caasp-csi-attacher:%%PKG_VERSION%%"/>
+          <label name="com.suse.caasp.v4.title" value="csi-attacher container"/>
+          <label name="com.suse.caasp.v4.version" value="%%PKG_VERSION%%"/>
+        </labels>
+      </containerconfig>
+    </type>
+    <version>1</version>
+    <packagemanager>zypper</packagemanager>
+    <rpm-excludedocs>true</rpm-excludedocs>
+  </preferences>
+  <repository>
+    <source path="obsrepositories:/"/>
+  </repository>
+  <packages type="image">
+    <package name="external-attacher"/>
+  </packages>
+</image>

--- a/caasp-csi-node-driver-registrar-image/_service
+++ b/caasp-csi-node-driver-registrar-image/_service
@@ -1,0 +1,8 @@
+<services>
+    <service name="replace_using_package_version" mode="buildtime">
+        <param name="file">caasp-csi-node-driver-registrar-image.kiwi</param>
+        <param name="regex">%%PKG_VERSION%%</param>
+        <param name="parse-version">patch</param>
+        <param name="package">node-driver-registrar</param>
+    </service>
+</services>

--- a/caasp-csi-node-driver-registrar-image/caasp-csi-node-driver-registrar-image.kiwi
+++ b/caasp-csi-node-driver-registrar-image/caasp-csi-node-driver-registrar-image.kiwi
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- OBS-AddTag: caasp/v4/cloud-provider-openstack:%%PKG_VERSION%%-rev<VERSION> caasp/v4/cloud-provider-openstack:%%PKG_VERSION%%-rev<VERSION>-build<RELEASE> caasp/v4/cloud-provider-openstack:beta -->
+
+<!--
+    PLEASE, REMOVE BETA TAG ON RELEASE
+-->
+<image schemaversion="6.9" name="caasp-csi-node-driver-registrar">
+  <description type="system">
+    <author>SUSE Containers Team</author>
+    <contact>containers@suse.com</contact>
+    <specification>caasp-csi-node-driver-registrar binary on SLES15 container guest</specification>
+  </description>
+  <preferences>
+    <type
+      image="docker"
+      derived_from="obsrepositories:/suse/sle15#15.1">
+      <containerconfig
+        name="caasp/v4/caasp-csi-node-driver-registrar"
+        tag="%%PKG_VERSION%%"
+        maintainer="SUSE Containers Team &lt;containers@suse.com&gt;">
+        <entrypoint execute="/usr/bin/csi-node-driver-registrar"/>
+        <subcommand clear="true"/>
+        <labels>
+          <label name="com.suse.caasp.v4.description" value="caasp-csi-node-driver-registrar binary on SLES15 container guest"/>
+          <label name="com.suse.caasp.v4.reference" value="caasp/v4/caasp-csi-node-driver-registrar:%%PKG_VERSION%%"/>
+          <label name="com.suse.caasp.v4.title" value="csi-node-driver-registrar container"/>
+          <label name="com.suse.caasp.v4.version" value="%%PKG_VERSION%%"/>
+        </labels>
+      </containerconfig>
+    </type>
+    <version>1</version>
+    <packagemanager>zypper</packagemanager>
+    <rpm-excludedocs>true</rpm-excludedocs>
+  </preferences>
+  <repository>
+    <source path="obsrepositories:/"/>
+  </repository>
+  <packages type="image">
+    <package name="node-driver-registrar"/>
+  </packages>
+</image>

--- a/caasp-csi-provisioner-image/_service
+++ b/caasp-csi-provisioner-image/_service
@@ -1,0 +1,8 @@
+<services>
+    <service name="replace_using_package_version" mode="buildtime">
+        <param name="file">caasp-csi-provisioner-image.kiwi</param>
+        <param name="regex">%%PKG_VERSION%%</param>
+        <param name="parse-version">patch</param>
+        <param name="package">external-provisioner</param>
+    </service>
+</services>

--- a/caasp-csi-provisioner-image/caasp-csi-provisioner-image.kiwi
+++ b/caasp-csi-provisioner-image/caasp-csi-provisioner-image.kiwi
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- OBS-AddTag: caasp/v4/cloud-provider-openstack:%%PKG_VERSION%%-rev<VERSION> caasp/v4/cloud-provider-openstack:%%PKG_VERSION%%-rev<VERSION>-build<RELEASE> caasp/v4/cloud-provider-openstack:beta -->
+
+<!--
+    PLEASE, REMOVE BETA TAG ON RELEASE
+-->
+<image schemaversion="6.9" name="caasp-csi-provisioner">
+  <description type="system">
+    <author>SUSE Containers Team</author>
+    <contact>containers@suse.com</contact>
+    <specification>caasp-csi-provisioner binary on SLES15 container guest</specification>
+  </description>
+  <preferences>
+    <type
+      image="docker"
+      derived_from="obsrepositories:/suse/sle15#15.1">
+      <containerconfig
+        name="caasp/v4/caasp-csi-provisioner"
+        tag="%%PKG_VERSION%%"
+        maintainer="SUSE Containers Team &lt;containers@suse.com&gt;">
+        <entrypoint execute="/usr/bin/csi-provisioner"/>
+        <subcommand clear="true"/>
+        <labels>
+          <label name="com.suse.caasp.v4.description" value="caasp-csi-provisioner binary on SLES15 container guest"/>
+          <label name="com.suse.caasp.v4.reference" value="caasp/v4/caasp-csi-provisioner:%%PKG_VERSION%%"/>
+          <label name="com.suse.caasp.v4.title" value="csi-provisioner container"/>
+          <label name="com.suse.caasp.v4.version" value="%%PKG_VERSION%%"/>
+        </labels>
+      </containerconfig>
+    </type>
+    <version>1</version>
+    <packagemanager>zypper</packagemanager>
+    <rpm-excludedocs>true</rpm-excludedocs>
+  </preferences>
+  <repository>
+    <source path="obsrepositories:/"/>
+  </repository>
+  <packages type="image">
+    <package name="external-provisioner"/>
+  </packages>
+</image>

--- a/caasp-csi-resizer-image/_service
+++ b/caasp-csi-resizer-image/_service
@@ -1,0 +1,8 @@
+<services>
+    <service name="replace_using_package_version" mode="buildtime">
+        <param name="file">caasp-csi-resizer-image.kiwi</param>
+        <param name="regex">%%PKG_VERSION%%</param>
+        <param name="parse-version">patch</param>
+        <param name="package">external-resizer</param>
+    </service>
+</services>

--- a/caasp-csi-resizer-image/caasp-csi-resizer-image.kiwi
+++ b/caasp-csi-resizer-image/caasp-csi-resizer-image.kiwi
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- OBS-AddTag: caasp/v4/cloud-provider-openstack:%%PKG_VERSION%%-rev<VERSION> caasp/v4/cloud-provider-openstack:%%PKG_VERSION%%-rev<VERSION>-build<RELEASE> caasp/v4/cloud-provider-openstack:beta -->
+
+<!--
+    PLEASE, REMOVE BETA TAG ON RELEASE
+-->
+<image schemaversion="6.9" name="caasp-csi-resizer">
+  <description type="system">
+    <author>SUSE Containers Team</author>
+    <contact>containers@suse.com</contact>
+    <specification>caasp-csi-resizer binary on SLES15 container guest</specification>
+  </description>
+  <preferences>
+    <type
+      image="docker"
+      derived_from="obsrepositories:/suse/sle15#15.1">
+      <containerconfig
+        name="caasp/v4/caasp-csi-resizer"
+        tag="%%PKG_VERSION%%"
+        maintainer="SUSE Containers Team &lt;containers@suse.com&gt;">
+        <entrypoint execute="/usr/bin/csi-resizer"/>
+        <subcommand clear="true"/>
+        <labels>
+          <label name="com.suse.caasp.v4.description" value="caasp-csi-resizer binary on SLES15 container guest"/>
+          <label name="com.suse.caasp.v4.reference" value="caasp/v4/caasp-csi-resizer:%%PKG_VERSION%%"/>
+          <label name="com.suse.caasp.v4.title" value="csi-resizer container"/>
+          <label name="com.suse.caasp.v4.version" value="%%PKG_VERSION%%"/>
+        </labels>
+      </containerconfig>
+    </type>
+    <version>1</version>
+    <packagemanager>zypper</packagemanager>
+    <rpm-excludedocs>true</rpm-excludedocs>
+  </preferences>
+  <repository>
+    <source path="obsrepositories:/"/>
+  </repository>
+  <packages type="image">
+    <package name="external-resizer"/>
+  </packages>
+</image>

--- a/caasp-csi-snapshotter-image/_service
+++ b/caasp-csi-snapshotter-image/_service
@@ -1,0 +1,8 @@
+<services>
+    <service name="replace_using_package_version" mode="buildtime">
+        <param name="file">caasp-csi-snapshotter-image.kiwi</param>
+        <param name="regex">%%PKG_VERSION%%</param>
+        <param name="parse-version">patch</param>
+        <param name="package">external-snapshotter</param>
+    </service>
+</services>

--- a/caasp-csi-snapshotter-image/caasp-csi-snapshotter-image.kiwi
+++ b/caasp-csi-snapshotter-image/caasp-csi-snapshotter-image.kiwi
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- OBS-AddTag: caasp/v4/cloud-provider-openstack:%%PKG_VERSION%%-rev<VERSION> caasp/v4/cloud-provider-openstack:%%PKG_VERSION%%-rev<VERSION>-build<RELEASE> caasp/v4/cloud-provider-openstack:beta -->
+
+<!--
+    PLEASE, REMOVE BETA TAG ON RELEASE
+-->
+<image schemaversion="6.9" name="caasp-csi-snapshotter">
+  <description type="system">
+    <author>SUSE Containers Team</author>
+    <contact>containers@suse.com</contact>
+    <specification>caasp-csi-snapshotter binary on SLES15 container guest</specification>
+  </description>
+  <preferences>
+    <type
+      image="docker"
+      derived_from="obsrepositories:/suse/sle15#15.1">
+      <containerconfig
+        name="caasp/v4/caasp-csi-snapshotter"
+        tag="%%PKG_VERSION%%"
+        maintainer="SUSE Containers Team &lt;containers@suse.com&gt;">
+        <entrypoint execute="/usr/bin/csi-snapshotter"/>
+        <subcommand clear="true"/>
+        <labels>
+          <label name="com.suse.caasp.v4.description" value="caasp-csi-snapshotter binary on SLES15 container guest"/>
+          <label name="com.suse.caasp.v4.reference" value="caasp/v4/caasp-csi-snapshotter:%%PKG_VERSION%%"/>
+          <label name="com.suse.caasp.v4.title" value="csi-snapshotter container"/>
+          <label name="com.suse.caasp.v4.version" value="%%PKG_VERSION%%"/>
+        </labels>
+      </containerconfig>
+    </type>
+    <version>1</version>
+    <packagemanager>zypper</packagemanager>
+    <rpm-excludedocs>true</rpm-excludedocs>
+  </preferences>
+  <repository>
+    <source path="obsrepositories:/"/>
+  </repository>
+  <packages type="image">
+    <package name="external-snapshotter"/>
+  </packages>
+</image>


### PR DESCRIPTION
Adds new containers that will be needed to run the external cloud provider integrations.

The first provider that will need this is `openstack`.

Before this request can be merged the following packages need to be merged into the `Devel:CaaSP:4.0` repository:

* https://build.suse.de/request/show/197486

* https://build.suse.de/request/show/197485

* https://build.suse.de/request/show/197484

* https://build.suse.de/request/show/197483

* https://build.suse.de/request/show/197482