### PR TITLE
Cilium proxy is not available in CaaSPv4-RC1. It will be later.

### DIFF
--- a/caasp-cilium-image/caasp-cilium-image.kiwi
+++ b/caasp-cilium-image/caasp-cilium-image.kiwi
@@ -40,6 +40,7 @@
     <package name="cilium"/>
     <package name="cilium-cni"/>
     <package name="libboringssl0"/>
-    <package name="cilium-proxy"/>
+    <!-- CaaSP4 has not now (Beta5) cilium-proxy. It will have on a later stage, so I will keep this commented for now -->
+    <!--    <package name="cilium-proxy"/> -->
   </packages>
 </image>


### PR DESCRIPTION
Signed-off-by: Jordi Massaguer Pla <jmassaguerpla@suse.de>