### PR TITLE
Fix nss tool not installed

### DIFF
--- a/caasp-389-ds-image/caasp-389-ds-image.kiwi
+++ b/caasp-389-ds-image/caasp-389-ds-image.kiwi
@@ -46,5 +46,6 @@
   <packages type="image">
     <package name="389-ds"/>
     <package name="gawk"/>
+    <package name="mozilla-nss-tools"/>
   </packages>
 </image>


### PR DESCRIPTION
Bug 1148735 - Fix NSS Tool not install after recent 389-ds update.