### PR TITLE
cilium: Add cilium-proxy and remove BoringSSL

### DIFF
--- a/caasp-cilium-image/caasp-cilium-image.kiwi
+++ b/caasp-cilium-image/caasp-cilium-image.kiwi
@@ -42,8 +42,6 @@
   <packages type="image">
     <package name="cilium"/>
     <package name="cilium-cni"/>
-    <package name="libboringssl0"/>
-    <!-- CaaSP4 has not now (Beta5) cilium-proxy. It will have on a later stage, so I will keep this commented for now -->
-    <!--    <package name="cilium-proxy"/> -->
+    <package name="cilium-proxy"/>
   </packages>
 </image>


### PR DESCRIPTION
cilium-proxy is a package which provides the Envoy proxy with additional
Cilium filters. Envoy proxy is responsible for implementing L7 network
policies.

This change also removes dependency on BoringSSL, because now our
cilium-proxy and envoy-proxy packages contain patches which allow us to
use OpenSSL instead of BoringSSL.

Signed-off-by: Michal Rostecki <mrostecki@opensuse.org>