### PR TITLE
Bump kured image version

### DIFF
--- a/caasp-kured-image/caasp-kured-image.kiwi
+++ b/caasp-kured-image/caasp-kured-image.kiwi
@@ -32,7 +32,7 @@
         </labels>
       </containerconfig>
     </type>
-    <version>3</version>
+    <version>4</version>
     <packagemanager>zypper</packagemanager>
     <rpm-excludedocs>true</rpm-excludedocs>
   </preferences>


### PR DESCRIPTION
The kured image is bumped because the kured package has introduced
a new required patch to support current 1.16 k8s and avoid deprecated
and deleted API methods. Since this was a patch no version bump
happend in kured package, thus the resolved tag remains the same
unless we bump the image version manually.