### PR TITLE
Fix velero dir and restic name

### DIFF
--- a/caasp-velero-image/caasp-velero-image.kiwi
+++ b/caasp-velero-image/caasp-velero-image.kiwi
@@ -17,7 +17,7 @@
         tag="%%PKG_VERSION%%"
         maintainer="SUSE Containers Team &lt;containers@suse.com&gt;"
         user="nobody">
-        <entrypoint execute="/velero"/>
+        <entrypoint execute="/usr/bin/velero"/>
         <subcommand clear="true"/>
         <labels>
           <suse_label_helper:add_prefix prefix="com.suse.caasp.v4">

--- a/caasp-velero-restic-restore-helper-image/_service
+++ b/caasp-velero-restic-restore-helper-image/_service
@@ -3,7 +3,7 @@
         <param name="file">caasp-velero-restic-restore-helper-image.kiwi</param>
         <param name="regex">%%PKG_VERSION%%</param>
         <param name="parse-version">patch</param>
-        <param name="package">velero-velero-restic-restore-helper</param>
+        <param name="package">velero-restic-restore-helper</param>
     </service>
     <service mode="buildtime" name="kiwi_metainfo_helper"/>
     <service mode="buildtime" name="kiwi_label_helper"/>

--- a/caasp-velero-restic-restore-helper-image/caasp-velero-restic-restore-helper-image.kiwi
+++ b/caasp-velero-restic-restore-helper-image/caasp-velero-restic-restore-helper-image.kiwi
@@ -17,7 +17,7 @@
         tag="%%PKG_VERSION%%"
         maintainer="SUSE Containers Team &lt;containers@suse.com&gt;"
         user="nobody">
-        <entrypoint execute="/velero-restic-restore-helper"/>
+        <entrypoint execute="/usr/bin/velero-restic-restore-helper"/>
         <subcommand clear="true"/>
         <labels>
           <suse_label_helper:add_prefix prefix="com.suse.caasp.v4">

--- a/caasp-velero-restic-restore-helper-image/caasp-velero-restic-restore-helper-image.kiwi
+++ b/caasp-velero-restic-restore-helper-image/caasp-velero-restic-restore-helper-image.kiwi
@@ -41,7 +41,7 @@
     <source path="obsrepositories:/"/>
   </repository>
   <packages type="image">
-    <package name="velero-velero-restic-restore-helper"/>
+    <package name="velero-restic-restore-helper"/>
     <package name="system-user-nobody"/>
   </packages>
 </image>


### PR DESCRIPTION
Put velero and velero-restic-restore-helper to `/usr/bin` and drop the duplicate `velero-` prefix from `velero-restic-restore-helper` (see https://github.com/SUSE/caasp-container-images/pull/45#pullrequestreview-337940127 and https://build.suse.de/request/show/208735)