### PR TITLE
Set k8s-sidecar workingdir path

### DIFF
--- a/caasp-k8s-sidecar-image/caasp-k8s-sidecar-image.kiwi
+++ b/caasp-k8s-sidecar-image/caasp-k8s-sidecar-image.kiwi
@@ -16,9 +16,11 @@
         name="caasp/v4/k8s-sidecar"
         tag="%%PKG_VERSION%%"
         maintainer="SUSE Containers Team &lt;containers@suse.com&gt;"
-        user="nobody">
+        user="nobody"
+        workingdir="/usr/share/k8s-sidecar/sidecar">
         <entrypoint execute="/usr/bin/python3">
-          <argument name="/usr/share/k8s-sidecar/sidecar/sidecar.py"/>
+          <argument name="-u"/>
+          <argument name="sidecar.py"/>
         </entrypoint>
         <subcommand clear="true"/>
         <labels>


### PR DESCRIPTION
`/usr/share/k8s-sidecar/sidecar/sidecar.py` calls `/usr/share/k8s-sidecar/sidecar/resources.py` and `/usr/share/k8s-sidecar/sidecar/helpers.py`.

Set the **workdir** to `/usr/share/k8s-sidecar/sidecar` so the `sidecar.py` could call `resources.py` and `helpers.py` successfully.

Also set the "-u" flag aligns with https://github.com/kiwigrid/k8s-sidecar/blob/0.1.75/Dockerfile#L14.

Signed-off-by: JenTing Hsiao <jenting.hsiao@suse.com>