### PR TITLE
Update istio-pilot-image

### DIFF
--- a/caasp-istio-pilot-image/caasp-istio-pilot-image.kiwi
+++ b/caasp-istio-pilot-image/caasp-istio-pilot-image.kiwi
@@ -1,33 +1,33 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<!-- OBS-AddTag: caasp/v4/istio-pilot:%%PKG_VERSION%%-rev<VERSION> caasp/v4/istio-pilot:%%PKG_VERSION%%-rev<VERSION>-build<RELEASE> -->
+<!-- OBS-AddTag: caasp/v5/istio-pilot:%%PKG_VERSION%%-rev<VERSION> caasp/v5/istio-pilot:%%PKG_VERSION%%-rev<VERSION>-build<RELEASE> caasp/v5/istio-pilot:beta -->
 
 <image schemaversion="6.9" name="caasp-istio-pilot-image" xmlns:suse_label_helper="com.suse.label_helper">
   <description type="system">
     <author>SUSE Containers Team</author>
     <contact>containers@suse.com</contact>
-    <specification>Istio Pilot running on SLE15 SP1 container guest</specification>
+    <specification>Istio Pilot running on SLE15 SP2 container guest</specification>
   </description>
   <preferences>
     <type
       image="docker"
-      derived_from="obsrepositories:/suse/sle15#15.1">
+      derived_from="obsrepositories:/suse/sle15#15.2">
       <containerconfig
-        name="caasp/v4/istio-pilot"
+        name="caasp/v5/istio-pilot"
         tag="%%PKG_VERSION%%"
         maintainer="SUSE Containers Team &lt;containers@suse.com&gt;">
-        <entrypoint execute="/usr/lib64/istio/pilot-discovery"/>
+      <entrypoint execute="/usr/bin/pilot-discovery"/>
         <subcommand clear="true"/>
         <labels>
-          <suse_label_helper:add_prefix prefix="com.suse.caasp.v4">
-            <label name="com.suse.caasp.v4.description" value="Istio Pilot running on an SLES15 SP1 container guest"/>
-            <label name="com.suse.caasp.v4.title" value="Istio Pilot container"/>
+          <suse_label_helper:add_prefix prefix="com.suse.caasp.v5">
+            <label name="com.suse.caasp.v5.description" value="Istio Pilot running on an SLES15 SP2 container guest"/>
+            <label name="com.suse.caasp.v5.title" value="Istio Pilot container"/>
             <label name="org.opencontainers.image.created" value="%BUILDTIME%"/>
             <label name="org.opencontainers.image.vendor" value="SUSE LLC"/>
             <label name="org.opencontainers.image.url" value="https://www.suse.com/products/caas-platform/"/>
             <label name="org.opencontainers.image.version" value="%%PKG_VERSION%%"/>
             <label name="org.openbuildservice.disturl" value="%DISTURL%"/>
-            <label name="com.suse.reference" value="registry.suse.com/caasp/v4/istio-pilot:%%PKG_VERSION%%"/>
+            <label name="com.suse.reference" value="registry.suse.com/caasp/v5/istio-pilot:%%PKG_VERSION%%"/>
           </suse_label_helper:add_prefix>
         </labels>
       </containerconfig>
@@ -40,6 +40,6 @@
     <source path="obsrepositories:/"/>
   </repository>
   <packages type="image">
-    <package name="istio"/>
+    <package name="istio-pilot-discovery"/>
   </packages>
 </image>


### PR DESCRIPTION
Update the base OS, the entrypoint and the caasp version.

Now it is in sync with what we have in Devel:CaaSP:5:Containers:CR/

Signed-off-by: Manuel Buil <mbuil@suse.com>