### PR TITLE
Bump caasp-dex version to 6 (bsc#1173055)

### DIFF
--- a/caasp-caasp-dex-image/caasp-caasp-dex-image.kiwi
+++ b/caasp-caasp-dex-image/caasp-caasp-dex-image.kiwi
@@ -32,7 +32,7 @@
         </labels>
       </containerconfig> 
     </type>
-    <version>5</version>
+    <version>6</version>
     <packagemanager>zypper</packagemanager>
     <rpm-excludedocs>true</rpm-excludedocs>
   </preferences>


### PR DESCRIPTION
Bump caasp-dex container image version to allow picking up the new image with caasp-dex bugfix.

refs: https://build.suse.de/request/show/221183
xrefs: https://github.com/SUSE/avant-garde/issues/1766

Signed-off-by: JenTing Hsiao <jenting.hsiao@suse.com>