### PR TITLE
Make use of the new versioned k8s packages

### DIFF
--- a/caasp-kube-apiserver-image/_service
+++ b/caasp-kube-apiserver-image/_service
@@ -3,7 +3,7 @@
         <param name="file">caasp-kube-apiserver-image.kiwi</param>
         <param name="regex">%%PKG_VERSION%%</param>
         <param name="parse-version">patch</param>
-        <param name="package">kubernetes-apiserver</param>
+        <param name="package">kubernetes-1.18-apiserver</param>
     </service>
     <service mode="buildtime" name="kiwi_metainfo_helper"/>
     <service mode="buildtime" name="kiwi_label_helper"/>

--- a/caasp-kube-apiserver-image/caasp-kube-apiserver-image.kiwi
+++ b/caasp-kube-apiserver-image/caasp-kube-apiserver-image.kiwi
@@ -32,7 +32,7 @@
         </labels>
       </containerconfig>
     </type>
-    <version>1</version>
+    <version>2</version>
     <packagemanager>zypper</packagemanager>
     <rpm-excludedocs>true</rpm-excludedocs>
   </preferences>
@@ -40,6 +40,6 @@
     <source path="obsrepositories:/"/>
   </repository>
   <packages type="image">
-    <package name="kubernetes-apiserver"/>
+    <package name="kubernetes-1.18-apiserver"/>
   </packages>
 </image>

--- a/caasp-kube-controller-manager-image/_service
+++ b/caasp-kube-controller-manager-image/_service
@@ -3,7 +3,7 @@
         <param name="file">caasp-kube-controller-manager-image.kiwi</param>
         <param name="regex">%%PKG_VERSION%%</param>
         <param name="parse-version">patch</param>
-        <param name="package">kubernetes-controller-manager</param>
+        <param name="package">kubernetes-1.18-controller-manager</param>
     </service>
     <service mode="buildtime" name="kiwi_metainfo_helper"/>
     <service mode="buildtime" name="kiwi_label_helper"/>

--- a/caasp-kube-controller-manager-image/caasp-kube-controller-manager-image.kiwi
+++ b/caasp-kube-controller-manager-image/caasp-kube-controller-manager-image.kiwi
@@ -32,7 +32,7 @@
         </labels>
       </containerconfig>
     </type>
-    <version>1</version>
+    <version>2</version>
     <packagemanager>zypper</packagemanager>
     <rpm-excludedocs>true</rpm-excludedocs>
   </preferences>
@@ -40,7 +40,7 @@
     <source path="obsrepositories:/"/>
   </repository>
   <packages type="image">
-    <package name="kubernetes-controller-manager"/>
+    <package name="kubernetes-1.18-controller-manager"/>
     <package name="ceph-common"/>
   </packages>
 </image>

--- a/caasp-kube-proxy-image/_service
+++ b/caasp-kube-proxy-image/_service
@@ -3,7 +3,7 @@
         <param name="file">caasp-kube-proxy-image.kiwi</param>
         <param name="regex">%%PKG_VERSION%%</param>
         <param name="parse-version">patch</param>
-        <param name="package">kubernetes-proxy</param>
+        <param name="package">kubernetes-1.18-proxy</param>
     </service>
     <service mode="buildtime" name="kiwi_metainfo_helper"/>
     <service mode="buildtime" name="kiwi_label_helper"/>

--- a/caasp-kube-proxy-image/caasp-kube-proxy-image.kiwi
+++ b/caasp-kube-proxy-image/caasp-kube-proxy-image.kiwi
@@ -32,7 +32,7 @@
         </labels>
       </containerconfig>
     </type>
-    <version>1</version>
+    <version>2</version>
     <packagemanager>zypper</packagemanager>
     <rpm-excludedocs>true</rpm-excludedocs>
   </preferences>
@@ -40,7 +40,7 @@
     <source path="obsrepositories:/"/>
   </repository>
   <packages type="image">
-    <package name="kubernetes-proxy"/>
+    <package name="kubernetes-1.18-proxy"/>
     <package name="iptables"/>
     <package name="iproute2"/>
     <package name="conntrack-tools"/>

--- a/caasp-kube-scheduler-image/_service
+++ b/caasp-kube-scheduler-image/_service
@@ -3,7 +3,7 @@
         <param name="file">caasp-kube-scheduler-image.kiwi</param>
         <param name="regex">%%PKG_VERSION%%</param>
         <param name="parse-version">patch</param>
-        <param name="package">kubernetes-scheduler</param>
+        <param name="package">kubernetes-1.18-scheduler</param>
     </service>
     <service mode="buildtime" name="kiwi_metainfo_helper"/>
     <service mode="buildtime" name="kiwi_label_helper"/>

--- a/caasp-kube-scheduler-image/caasp-kube-scheduler-image.kiwi
+++ b/caasp-kube-scheduler-image/caasp-kube-scheduler-image.kiwi
@@ -32,7 +32,7 @@
         </labels>
       </containerconfig>
     </type>
-    <version>1</version>
+    <version>2</version>
     <packagemanager>zypper</packagemanager>
     <rpm-excludedocs>true</rpm-excludedocs>
   </preferences>
@@ -40,6 +40,6 @@
     <source path="obsrepositories:/"/>
   </repository>
   <packages type="image">
-    <package name="kubernetes-scheduler"/>
+    <package name="kubernetes-1.18-scheduler"/>
   </packages>
 </image>

--- a/caasp-kubernetes-client-image/_service
+++ b/caasp-kubernetes-client-image/_service
@@ -3,7 +3,7 @@
         <param name="file">caasp-kubernetes-client-image.kiwi</param>
         <param name="regex">%%PKG_VERSION%%</param>
         <param name="parse-version">patch</param>
-        <param name="package">kubernetes-client</param>
+        <param name="package">kubernetes-1.18-client</param>
     </service>
     <service mode="buildtime" name="kiwi_metainfo_helper"/>
     <service mode="buildtime" name="kiwi_label_helper"/>

--- a/caasp-kubernetes-client-image/caasp-kubernetes-client-image.kiwi
+++ b/caasp-kubernetes-client-image/caasp-kubernetes-client-image.kiwi
@@ -32,7 +32,7 @@
         </labels>
       </containerconfig>
     </type>
-    <version>1</version>
+    <version>2</version>
     <packagemanager>zypper</packagemanager>
     <rpm-excludedocs>true</rpm-excludedocs>
   </preferences>
@@ -40,6 +40,6 @@
     <source path="obsrepositories:/"/>
   </repository>
   <packages type="image">
-    <package name="kubernetes-client"/>
+    <package name="kubernetes-1.18-client"/>
   </packages>
 </image>


### PR DESCRIPTION
In CaaSP v5 k8s packages include the minor version in its name. This
needs to be reflected on the k8s image definitions.

This changes are required in order to align with SUSE/skuba#1178