### PR TITLE
Add curl to the list of packages

### DIFF
--- a/caasp-istio-proxyv2-image/caasp-istio-proxyv2-image.kiwi
+++ b/caasp-istio-proxyv2-image/caasp-istio-proxyv2-image.kiwi
@@ -42,5 +42,6 @@
   <packages type="image">
     <package name="istio-pilot-agent"/>
     <package name="cilium-istio-proxy"/>
+    <package name="curl"/>
   </packages>
 </image>


### PR DESCRIPTION
Curl must be part of the image because it is used for debugging stuff as
explained in the upstream documentation

Signed-off-by: Manuel Buil <mbuil@suse.com>