### PR TITLE
Change the path of the pilot-agent

### DIFF
--- a/caasp-istio-proxyv2-image/caasp-istio-proxyv2-image.kiwi
+++ b/caasp-istio-proxyv2-image/caasp-istio-proxyv2-image.kiwi
@@ -16,7 +16,7 @@
         name="caasp/v5/istio-proxyv2"
         tag="%%PKG_VERSION%%"
         maintainer="SUSE Containers Team &lt;containers@suse.com&gt;">
-        <entrypoint execute="/usr/bin/pilot-agent"/>
+        <entrypoint execute="/usr/local/bin/pilot-agent"/>
         <subcommand clear="true"/>
         <labels>
           <suse_label_helper:add_prefix prefix="com.suse.caasp.v5">

--- a/caasp-istio-proxyv2-image/config.sh
+++ b/caasp-istio-proxyv2-image/config.sh
@@ -1,3 +1,4 @@
 #!/usr/bin/sh
 mkdir -p /usr/local/bin
 ln -s /usr/bin/envoy /usr/local/bin/envoy
+ln -s /usr/bin/pilot-agent /usr/local/bin/pilot-agent


### PR DESCRIPTION
When debugging stuff in Istio, we should try to always use the tool
istioctl. That tool calls the pilot-agent command of the envoy proxy and
it expects it to be in the path: /usr/local/bin/pilot-agent. Otherwise,
it fails with:

```
Error: failed to execute command on sidecar: error execing into istio-ingressgateway-7df959db-6tmgl/istio-system istio-proxy container: command terminated with exit code 1
time="2020-06-30T18:10:00+02:00" level=error msg="exec failed: container_linux.go:349: starting container process caused \"exec: \\\"/usr/local/bin/pilot-agent\\\": stat /usr/local/bin/pilot-agent: no such file or directory\""
exec failed: container_linux.go:349: starting container process caused "exec: \"/usr/local/bin/pilot-agent\": stat /usr/local/bin/pilot-agent: no such file or directory"
```

Signed-off-by: Manuel Buil <mbuil@suse.com>