### PR TITLE
[WIP] Create config.sh to fix entrypoint permissions

### DIFF
--- a/caasp-grafana-image/config.sh
+++ b/caasp-grafana-image/config.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+################################################################################
+# config.sh runs at the end of the prepare step, after users have been set,
+# packages installed, and the overlay filesystem created.
+################################################################################
+# http://osinside.github.io/kiwi/working_with_kiwi/shell_scripts.html
+# include Kiwi functions and vars
+test -f /.kconfig && . /.kconfig
+test -f /.profile && . /.profile
+
+OLDIFS="$IFS"  # to restore normal behavior
+DIRIFS="/$IFS" # to split directory components
+
+entrypoint="./usr/local/bin/entrypoint.sh"
+if [ -f $entrypoint ]
+then
+    Debug "Setting recursive permissions on entrypoint '$entrypoint'"
+    p=""
+    IFS="$DIRIFS"
+    for component in $entrypoint
+    do
+        IFS="$OLDIFS"
+        p="${p:-}${p:+/}$component"
+        Debug $(chmod -v 0755 "$p")
+        IFS="$DIRIFS"
+    done
+    IFS="$OLDIFS"
+else
+    Echo "Failed to find entrypoint '$entrypoint'; things will break"
+fi

--- a/caasp-grafana-image/config.sh
+++ b/caasp-grafana-image/config.sh
@@ -12,7 +12,7 @@ OLDIFS="$IFS"  # to restore normal behavior
 DIRIFS="/$IFS" # to split directory components
 
 entrypoint="./usr/local/bin/entrypoint.sh"
-if [ -f $entrypoint ]
+if [ -f "$entrypoint" ]
 then
     Debug "Setting recursive permissions on entrypoint '$entrypoint'"
     p=""


### PR DESCRIPTION
Adding a script to address the root cause of SUSE/avant-garde#1763 and SUSE/avant-garde#1770.  I've not tested this with Kiwi yet, but it works as-expected stand-alone.  Opening a placeholder PR (well, with presumably working code; script works locally) as one possible solution to the issue.

The script itself ensures universal read and execute to the entrypoint script and all parent directories.

Ideally it'd pull the entrypoint from the .kiwi file instead of being hard-coded in the script, but parsing XML natively in a shell script seems unpleasant, and installing extra packages just for that is overkill.