### PR TITLE
[istio]Add base-image for istio to be used in other images

### DIFF
--- a/caasp-istio-base-image/Makefile
+++ b/caasp-istio-base-image/Makefile
@@ -1,0 +1,1 @@
+../.images.Makefile

--- a/caasp-istio-base-image/_service
+++ b/caasp-istio-base-image/_service
@@ -1,0 +1,10 @@
+<services>
+    <service name="replace_using_package_version" mode="buildtime">
+        <param name="file">caasp-istio-base-image.kiwi</param>
+        <param name="regex">%%PKG_VERSION%%</param>
+        <param name="parse-version">patch</param>
+        <param name="package">istio</param>
+    </service>
+    <service mode="buildtime" name="kiwi_metainfo_helper"/>
+    <service mode="buildtime" name="kiwi_label_helper"/>
+</services>

--- a/caasp-istio-base-image/caasp-istio-base-image.kiwi
+++ b/caasp-istio-base-image/caasp-istio-base-image.kiwi
@@ -1,33 +1,32 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<!-- OBS-AddTag: caasp/v5/istio-pilot:%%PKG_VERSION%%-rev<VERSION> caasp/v5/istio-pilot:%%PKG_VERSION%%-rev<VERSION>-build<RELEASE> caasp/v5/istio-pilot:beta -->
+<!-- OBS-AddTag: caasp/v5/istio-base:%%PKG_VERSION%%-rev<VERSION> caasp/v5/istio-base:%%PKG_VERSION%%-rev<VERSION>-build<RELEASE> caasp/v5/istio-base:beta -->
 
-<image schemaversion="6.9" name="caasp-istio-pilot-image" xmlns:suse_label_helper="com.suse.label_helper">
+<image schemaversion="6.9" name="caasp-istio-base-image" xmlns:suse_label_helper="com.suse.label_helper">
   <description type="system">
     <author>SUSE Containers Team</author>
     <contact>containers@suse.com</contact>
-    <specification>Istio Pilot running on SLE15 SP2 container guest</specification>
+    <specification>Istio base image built on SLE15 SP2 container guest</specification>
   </description>
   <preferences>
     <type
       image="docker"
-	    derived_from="obsrepositories:/caasp/v5/istio-base:%%PKG_VERSION%%">
+      derived_from="obsrepositories:/suse/sle15#15.2">
       <containerconfig
-        name="caasp/v5/istio-pilot"
+        name="caasp/v5/istio-base"
         tag="%%PKG_VERSION%%"
         maintainer="SUSE Containers Team &lt;containers@suse.com&gt;">
-      <entrypoint execute="/usr/bin/pilot-discovery"/>
         <subcommand clear="true"/>
         <labels>
           <suse_label_helper:add_prefix prefix="com.suse.caasp.v5">
-            <label name="com.suse.caasp.v5.description" value="Istio Pilot running on an SLES15 SP2 container guest"/>
-            <label name="com.suse.caasp.v5.title" value="Istio Pilot container"/>
+            <label name="com.suse.caasp.v5.description" value="Istio base image built on SLES15 SP2"/>
+            <label name="com.suse.caasp.v5.title" value="Istio Base container"/>
             <label name="org.opencontainers.image.created" value="%BUILDTIME%"/>
             <label name="org.opencontainers.image.vendor" value="SUSE LLC"/>
             <label name="org.opencontainers.image.url" value="https://www.suse.com/products/caas-platform/"/>
             <label name="org.opencontainers.image.version" value="%%PKG_VERSION%%"/>
             <label name="org.openbuildservice.disturl" value="%DISTURL%"/>
-            <label name="com.suse.reference" value="registry.suse.com/caasp/v5/istio-pilot:%%PKG_VERSION%%"/>
+            <label name="com.suse.reference" value="registry.suse.com/caasp/v5/istio-base:%%PKG_VERSION%%"/>
           </suse_label_helper:add_prefix>
         </labels>
       </containerconfig>
@@ -40,6 +39,17 @@
     <source path="obsrepositories:/"/>
   </repository>
   <packages type="image">
-    <package name="istio-pilot-discovery"/>
+      <package name="ca-certificates"/>
+      <package name="curl"/>
+      <package name="iptables"/>
+      <package name="iproute2"/>
+      <package name="iputils"/>
+      <package name="bind-utils"/>
+      <package name="netcat"/>
+      <package name="tcpdump"/>
+      <package name="net-tools"/>
+      <package name="lsof"/>
+      <package name="linux-tools"/>
+      <package name="istio"/>
   </packages>
 </image>

--- a/caasp-istio-proxyv2-image/caasp-istio-proxyv2-image.kiwi
+++ b/caasp-istio-proxyv2-image/caasp-istio-proxyv2-image.kiwi
@@ -11,7 +11,7 @@
   <preferences>
     <type
       image="docker"
-      derived_from="obsrepositories:/suse/sle15#15.2">
+	    derived_from="obsrepositories:/caasp/v5/istio-base:%%PKG_VERSION%%">
       <containerconfig
         name="caasp/v5/istio-proxyv2"
         tag="%%PKG_VERSION%%"
@@ -47,6 +47,5 @@
   <packages type="image">
     <package name="istio-pilot-agent"/>
     <package name="cilium-istio-proxy"/>
-    <package name="curl"/>
   </packages>
 </image>


### PR DESCRIPTION
Several common packages are installed in istio-pilot and proxy images. These are now independently installed in a separate istio-base image which derives from SLE12SP2 for CaasP5. The other istio images (istio-pilot and istio-proxyv2) will derive from the istio-base image.

https://github.com/SUSE/avant-garde/issues/1777