### PR TITLE
Add kubernetes client version to image


### DIFF
--- a/caasp-kucero-image/caasp-kucero-image.kiwi
+++ b/caasp-kucero-image/caasp-kucero-image.kiwi
@@ -32,7 +32,7 @@
         </labels>
       </containerconfig>
     </type>
-    <version>1</version>
+    <version>2</version>
     <packagemanager>zypper</packagemanager>
     <rpm-excludedocs>true</rpm-excludedocs>
   </preferences>
@@ -41,6 +41,6 @@
   </repository>
   <packages type="image">
     <package name="kucero"/>
-    <package name="kubernetes-client"/>
+    <package name="kubernetes-1.18-client"/>
   </packages>
 </image>

--- a/caasp-kured-image/caasp-kured-image.kiwi
+++ b/caasp-kured-image/caasp-kured-image.kiwi
@@ -32,7 +32,7 @@
         </labels>
       </containerconfig>
     </type>
-    <version>1</version>
+    <version>2</version>
     <packagemanager>zypper</packagemanager>
     <rpm-excludedocs>true</rpm-excludedocs>
   </preferences>
@@ -41,6 +41,6 @@
   </repository>
   <packages type="image">
     <package name="kured"/>
-    <package name="kubernetes-client"/>
+    <package name="kubernetes-1.18-client"/>
   </packages>
 </image>


### PR DESCRIPTION


There is no reason to allow the image to consume another
version of kubernetes-client than the necessary/tested one.

This makes it explicit.

