### PR TITLE
Bump cilium image version to 5

### DIFF
--- a/caasp-cilium-image/caasp-cilium-image.kiwi
+++ b/caasp-cilium-image/caasp-cilium-image.kiwi
@@ -32,7 +32,7 @@
         </labels>
       </containerconfig>
     </type>
-    <version>1</version>
+    <version>5</version>
     <packagemanager>zypper</packagemanager>
     <rpm-excludedocs>true</rpm-excludedocs>
   </preferences>


### PR DESCRIPTION
This pull request bumps caasp-cilium-image version to allow picking up new image with cilium bugfix for https://bugzilla.suse.com/show_bug.cgi?id=1173039.

Relevant avant-garde issue: SUSE/avant-garde#1744