### PR TITLE
Add container image support for Multus

### DIFF
--- a/caasp-multus-image/Makefile
+++ b/caasp-multus-image/Makefile
@@ -1,0 +1,1 @@
+../.images.Makefile

--- a/caasp-multus-image/_service
+++ b/caasp-multus-image/_service
@@ -1,0 +1,10 @@
+<services>
+    <service name="replace_using_package_version" mode="buildtime">
+        <param name="file">caasp-multus-image.kiwi</param>
+        <param name="regex">%%PKG_VERSION%%</param>
+        <param name="parse-version">patch</param>
+        <param name="package">multus-cni</param>
+    </service>
+    <service mode="buildtime" name="kiwi_metainfo_helper"/>
+    <service mode="buildtime" name="kiwi_label_helper"/>
+</services>

--- a/caasp-multus-image/caasp-multus-image.kiwi
+++ b/caasp-multus-image/caasp-multus-image.kiwi
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- OBS-AddTag: caasp/v5/multus:%%PKG_VERSION%%-rev<VERSION> caasp/v5/multus:%%PKG_VERSION%%-rev<VERSION>-build<RELEASE> -->
+
+<image schemaversion="6.9" name="caasp-multus-image" xmlns:suse_label_helper="com.suse.label_helper">
+  <description type="system">
+    <author>SUSE Containers Team</author>
+    <contact>containers@suse.com</contact>
+    <specification>Multus running in a SLES15 SP2 container</specification>
+  </description>
+  <preferences>
+    <type
+      image="docker"
+      derived_from="obsrepositories:/suse/sle15#15.2">
+      <containerconfig
+        name="caasp/v5/multus"
+        tag="%%PKG_VERSION%%"
+        maintainer="SUSE Containers Team &lt;containers@suse.com&gt;">
+        <entrypoint execute="/usr/bin/multus"/>
+        <subcommand clear="true"/>
+        <labels>
+          <suse_label_helper:add_prefix prefix="com.suse.caasp.v4">
+            <label name="org.opencontainers.image.description" value="Multus running in a SLES15 SP2 container"/>
+            <label name="org.opencontainers.image.title" value="Multus CNI container"/>
+            <label name="org.opencontainers.image.created" value="%BUILDTIME%"/>
+            <label name="org.opencontainers.image.vendor" value="SUSE LLC"/>
+            <label name="org.opencontainers.image.url" value="https://www.suse.com/products/caas-platform/"/>
+            <label name="org.opencontainers.image.version" value="%%PKG_VERSION%%"/>
+            <label name="org.openbuildservice.disturl" value="%DISTURL%"/>
+            <label name="com.suse.reference" value="registry.suse.com/caasp/v5/multus:%%PKG_VERSION%%"/>
+          </suse_label_helper:add_prefix>
+        </labels>
+      </containerconfig>
+    </type>
+    <version>1</version>
+    <packagemanager>zypper</packagemanager>
+    <rpm-excludedocs>true</rpm-excludedocs>
+  </preferences>
+  <repository>
+    <source path="obsrepositories:/"/>
+  </repository>
+  <packages type="image">
+    <package name="multus-cni"/>
+  </packages>
+</image>


### PR DESCRIPTION
This change adds the build manifest for the Multus container image.

https://github.com/SUSE/avant-garde/issues/1809