### PR TITLE
Bump cilium-image versions to 5

### DIFF
--- a/caasp-cilium-image/caasp-cilium-image.kiwi
+++ b/caasp-cilium-image/caasp-cilium-image.kiwi
@@ -32,7 +32,7 @@
         </labels>
       </containerconfig>
     </type>
-    <version>4</version>
+    <version>5</version>
     <packagemanager>zypper</packagemanager>
     <rpm-excludedocs>true</rpm-excludedocs>
   </preferences>

--- a/caasp-cilium-init-image/caasp-cilium-init-image.kiwi
+++ b/caasp-cilium-init-image/caasp-cilium-init-image.kiwi
@@ -32,7 +32,7 @@
         </labels>
       </containerconfig>
     </type>
-    <version>3</version>
+    <version>5</version>
     <packagemanager>zypper</packagemanager>
     <rpm-excludedocs>true</rpm-excludedocs>
   </preferences>

--- a/caasp-cilium-operator-image/caasp-cilium-operator-image.kiwi
+++ b/caasp-cilium-operator-image/caasp-cilium-operator-image.kiwi
@@ -33,7 +33,7 @@
         </labels>
       </containerconfig>
     </type>
-    <version>3</version>
+    <version>5</version>
     <packagemanager>zypper</packagemanager>
     <rpm-excludedocs>true</rpm-excludedocs>
   </preferences>


### PR DESCRIPTION
Cilium images need to be bumped to next revision (5) to pick up bugfix for (bsc#1173039) to be released with 4.2.2. 