### PR TITLE
Fixed istio-pilot and istio-proxyv2 image with right base version

### DIFF
--- a/caasp-istio-base-image/caasp-istio-base-image.kiwi
+++ b/caasp-istio-base-image/caasp-istio-base-image.kiwi
@@ -49,7 +49,7 @@
       <package name="tcpdump"/>
       <package name="net-tools"/>
       <package name="lsof"/>
-      <package name="linux-tools"/>
+      <!-- <package name="linux-tools"/> -->
       <package name="istio"/>
   </packages>
 </image>

--- a/caasp-istio-pilot-image/caasp-istio-pilot-image.kiwi
+++ b/caasp-istio-pilot-image/caasp-istio-pilot-image.kiwi
@@ -11,7 +11,7 @@
   <preferences>
     <type
       image="docker"
-	    derived_from="obsrepositories:/caasp/v5/istio-base:%%PKG_VERSION%%">
+	    derived_from="obsrepositories:/caasp/v5/istio-base#1.5.4">
       <containerconfig
         name="caasp/v5/istio-pilot"
         tag="%%PKG_VERSION%%"

--- a/caasp-istio-proxyv2-image/caasp-istio-proxyv2-image.kiwi
+++ b/caasp-istio-proxyv2-image/caasp-istio-proxyv2-image.kiwi
@@ -11,7 +11,7 @@
   <preferences>
     <type
       image="docker"
-	    derived_from="obsrepositories:/caasp/v5/istio-base:%%PKG_VERSION%%">
+      derived_from="obsrepositories:/caasp/v5/istio-base#1.5.4">
       <containerconfig
         name="caasp/v5/istio-proxyv2"
         tag="%%PKG_VERSION%%"


### PR DESCRIPTION
Base image now does not install linux-tools which is not available with SLE and is only a requirement for certain manual tests.
The istio-pilot and istio-proxyv2 images derive from istio-base#1.5.4 with successful image build.