### PR TITLE
Added updated default-http-backend-image needed by nginx-ingress

### DIFF
--- a/caasp-default-http-backend-image/Makefile
+++ b/caasp-default-http-backend-image/Makefile
@@ -1,0 +1,1 @@
+../.images.Makefile

--- a/caasp-default-http-backend-image/_service
+++ b/caasp-default-http-backend-image/_service
@@ -1,0 +1,10 @@
+<services>
+    <service name="replace_using_package_version" mode="buildtime">
+        <param name="file">caasp-default-http-backend-image.kiwi</param>
+        <param name="regex">%%PKG_VERSION%%</param>
+        <param name="parse-version">patch</param>
+        <param name="package">kubernetes-404-server</param>
+    </service>
+    <service mode="buildtime" name="kiwi_metainfo_helper"/>
+    <service mode="buildtime" name="kiwi_label_helper"/>
+</services>

--- a/caasp-default-http-backend-image/caasp-default-http-backend-image.kiwi
+++ b/caasp-default-http-backend-image/caasp-default-http-backend-image.kiwi
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- OBS-AddTag: caasp/v5/default-http-backend:%%PKG_VERSION%%-rev<VERSION> caasp/v5/default-http-backend:%%PKG_VERSION%%-rev<VERSION>-build<RELEASE> caasp/v5/default-http-backend:beta -->
+
+<image schemaversion="6.9" name="caasp-default-http-backend-image" xmlns:suse_label_helper="com.suse.label_helper">
+  <description type="system">
+    <author>SUSE Containers Team</author>
+    <contact>containers@suse.com</contact>
+    <specification>kubernetes-404-server running on an SLE15 container guest</specification>
+  </description>
+  <preferences>
+    <type
+      image="docker"
+      derived_from="obsrepositories:/suse/sle15#15.2">
+      <containerconfig
+        name="caasp/v5/default-http-backend"
+        tag="%%PKG_VERSION%%"
+        maintainer="SUSE Containers Team &lt;containers@suse.com&gt;">
+        <entrypoint execute="/usr/bin/kubernetes-404-server"/>
+        <subcommand clear="true"/>
+        <labels>
+          <suse_label_helper:add_prefix prefix="com.suse.caasp.v5">
+            <label name="com.suse.caasp.v5.description" value="Kubernetes-404-server running on an SLES15 SP2 container guest"/>
+            <label name="com.suse.caasp.v5.title" value="default-http-backend container"/>
+            <label name="org.opencontainers.image.created" value="%BUILDTIME%"/>
+            <label name="org.opencontainers.image.vendor" value="SUSE LLC"/>
+            <label name="org.opencontainers.image.url" value="https://www.suse.com/products/caas-platform/"/>
+            <label name="org.opencontainers.image.version" value="%%PKG_VERSION%%"/>
+            <label name="org.openbuildservice.disturl" value="%DISTURL%"/>
+            <label name="com.suse.reference" value="registry.suse.com/caasp/v5/default-http-backend:%%PKG_VERSION%%"/>
+          </suse_label_helper:add_prefix>
+        </labels>
+      </containerconfig> 
+    </type>
+    <version>1</version>
+    <packagemanager>zypper</packagemanager>
+    <rpm-excludedocs>true</rpm-excludedocs>
+  </preferences>
+  <repository>
+    <source path="obsrepositories:/"/>
+  </repository>
+  <packages type="image">
+    <package name="kubernetes-404-server"/>
+  </packages> 
+</image>
+


### PR DESCRIPTION
default-http-backend image needed for nginx Ingress use-case testing as a requirement for https://github.com/SUSE/avant-garde/issues/1847