### PR TITLE
rename v5 to v4.5

### DIFF
--- a/caasp-389-ds-image/caasp-389-ds-image.kiwi
+++ b/caasp-389-ds-image/caasp-389-ds-image.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<!-- OBS-AddTag: caasp/v5/389-ds:%%PKG_VERSION%%-rev<VERSION> caasp/v5/389-ds:%%PKG_VERSION%%-rev<VERSION>-build<RELEASE> caasp/v5/389-ds:beta -->
+<!-- OBS-AddTag: caasp/v4.5/389-ds:%%PKG_VERSION%%-rev<VERSION> caasp/v4.5/389-ds:%%PKG_VERSION%%-rev<VERSION>-build<RELEASE> caasp/v4.5/389-ds:beta -->
 
 <image schemaversion="6.9" name="caasp-389-ds-image" xmlns:suse_label_helper="com.suse.label_helper">
   <description type="system">
@@ -11,11 +11,11 @@
   <preferences>
     <type image="docker" derived_from="obsrepositories:/suse/sle15#15.2">
       <containerconfig
-        name="caasp/v5/389-ds"
+        name="caasp/v4.5/389-ds"
         tag="%%PKG_VERSION%%"
         maintainer="SUSE Containers Team &lt;containers@suse.com&gt;">
         <labels>
-          <suse_label_helper:add_prefix prefix="com.suse.caasp.v5">
+          <suse_label_helper:add_prefix prefix="com.suse.caasp.v4.5">
             <label name="org.opencontainers.image.description" value="CaaSP 389 Directory Server running on a SLES15 SP2 container guest"/>
             <label name="org.opencontainers.image.title" value="CaaSP 389 Directory Server container"/>
             <label name="org.opencontainers.image.created" value="%BUILDTIME%"/>
@@ -23,7 +23,7 @@
             <label name="org.opencontainers.image.url" value="https://www.suse.com/products/caas-platform/"/>
             <label name="org.opencontainers.image.version" value="%%PKG_VERSION%%"/>
             <label name="org.openbuildservice.disturl" value="%DISTURL%"/>
-            <label name="com.suse.reference" value="registry.suse.com/caasp/v5/389-ds:%%PKG_VERSION%%"/>
+            <label name="com.suse.reference" value="registry.suse.com/caasp/v4.5/389-ds:%%PKG_VERSION%%"/>
           </suse_label_helper:add_prefix>
         </labels>
         <expose>

--- a/caasp-busybox-image/caasp-busybox-image.kiwi
+++ b/caasp-busybox-image/caasp-busybox-image.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<!-- OBS-AddTag: caasp/v5/busybox:%%PKG_VERSION%%-rev<VERSION> caasp/v5/busybox:%%PKG_VERSION%%-rev<VERSION>-build<RELEASE> caasp/v5/busybox:beta -->
+<!-- OBS-AddTag: caasp/v4.5/busybox:%%PKG_VERSION%%-rev<VERSION> caasp/v4.5/busybox:%%PKG_VERSION%%-rev<VERSION>-build<RELEASE> caasp/v4.5/busybox:beta -->
 
 <image schemaversion="6.9" name="caasp-busybox-image" xmlns:suse_label_helper="com.suse.label_helper">
   <description type="system">
@@ -13,14 +13,14 @@
       image="docker"
       derived_from="obsrepositories:/suse/sle15#15.2">
       <containerconfig
-        name="caasp/v5/busybox"
+        name="caasp/v4.5/busybox"
         tag="%%PKG_VERSION%%"
         maintainer="SUSE Containers Team &lt;containers@suse.com&gt;"
         user="nobody">
         <entrypoint execute="busybox"/>
         <subcommand clear="true"/>
         <labels>
-          <suse_label_helper:add_prefix prefix="com.suse.caasp.v5">
+          <suse_label_helper:add_prefix prefix="com.suse.caasp.v4.5">
             <label name="org.opencontainers.image.description" value="busybox running on a SLES15 SP2 container guest"/>
             <label name="org.opencontainers.image.title" value="CaaSP busybox container"/>
             <label name="org.opencontainers.image.created" value="%BUILDTIME%"/>
@@ -28,7 +28,7 @@
             <label name="org.opencontainers.image.url" value="https://www.suse.com/products/caas-platform/"/>
             <label name="org.opencontainers.image.version" value="%%PKG_VERSION%%"/>
             <label name="org.openbuildservice.disturl" value="%DISTURL%"/>
-            <label name="com.suse.reference" value="registry.suse.com/caasp/v5/busybox:%%PKG_VERSION%%"/>
+            <label name="com.suse.reference" value="registry.suse.com/caasp/v4.5/busybox:%%PKG_VERSION%%"/>
           </suse_label_helper:add_prefix>
         </labels>
       </containerconfig>

--- a/caasp-caasp-dex-image/caasp-caasp-dex-image.kiwi
+++ b/caasp-caasp-dex-image/caasp-caasp-dex-image.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<!-- OBS-AddTag: caasp/v5/caasp-dex:%%PKG_VERSION%%-rev<VERSION> caasp/v5/caasp-dex:%%PKG_VERSION%%-rev<VERSION>-build<RELEASE> caasp/v5/caasp-dex:beta -->
+<!-- OBS-AddTag: caasp/v4.5/caasp-dex:%%PKG_VERSION%%-rev<VERSION> caasp/v4.5/caasp-dex:%%PKG_VERSION%%-rev<VERSION>-build<RELEASE> caasp/v4.5/caasp-dex:beta -->
 
 <image schemaversion="6.9" name="caasp-caasp-dex-image" xmlns:suse_label_helper="com.suse.label_helper">
   <description type="system">
@@ -13,13 +13,13 @@
       image="docker"
       derived_from="obsrepositories:/suse/sle15#15.2">
       <containerconfig
-        name="caasp/v5/caasp-dex"
+        name="caasp/v4.5/caasp-dex"
         tag="%%PKG_VERSION%%"
         maintainer="SUSE Containers Team &lt;containers@suse.com&gt;">
         <entrypoint execute="/usr/bin/caasp-dex"/>
         <subcommand execute="version"/>
         <labels>
-          <suse_label_helper:add_prefix prefix="com.suse.caasp.v5">
+          <suse_label_helper:add_prefix prefix="com.suse.caasp.v4.5">
             <label name="org.opencontainers.image.description" value="CaaSP caasp-dex running on a SLES15 SP2 container guest"/>
             <label name="org.opencontainers.image.title" value="CaaSP caasp-dex container"/>
             <label name="org.opencontainers.image.created" value="%BUILDTIME%"/>
@@ -27,7 +27,7 @@
             <label name="org.opencontainers.image.url" value="https://www.suse.com/products/caas-platform/"/>
             <label name="org.opencontainers.image.version" value="%%PKG_VERSION%%"/>
             <label name="org.openbuildservice.disturl" value="%DISTURL%"/>
-            <label name="com.suse.reference" value="registry.suse.com/caasp/v5/caasp-dex:%%PKG_VERSION%%"/>
+            <label name="com.suse.reference" value="registry.suse.com/caasp/v4.5/caasp-dex:%%PKG_VERSION%%"/>
           </suse_label_helper:add_prefix>
         </labels>
       </containerconfig> 

--- a/caasp-cert-exporter-image/caasp-cert-exporter-image.kiwi
+++ b/caasp-cert-exporter-image/caasp-cert-exporter-image.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<!-- OBS-AddTag: caasp/v5/cert-exporter:%%PKG_VERSION%%-rev<VERSION> caasp/v5/cert-exporter:%%PKG_VERSION%%-rev<VERSION>-build<RELEASE> caasp/v5/cert-exporter:beta -->
+<!-- OBS-AddTag: caasp/v4.5/cert-exporter:%%PKG_VERSION%%-rev<VERSION> caasp/v4.5/cert-exporter:%%PKG_VERSION%%-rev<VERSION>-build<RELEASE> caasp/v4.5/cert-exporter:beta -->
 
 <image schemaversion="6.9" name="caasp-cert-exporter-image" xmlns:suse_label_helper="com.suse.label_helper">
   <description type="system">
@@ -13,14 +13,14 @@
       image="docker"
       derived_from="obsrepositories:/suse/sle15#15.2">
       <containerconfig
-        name="caasp/v5/cert-exporter"
+        name="caasp/v4.5/cert-exporter"
         tag="%%PKG_VERSION%%"
         maintainer="SUSE Containers Team &lt;containers@suse.com&gt;"
         user="nobody">
         <entrypoint execute="cert-exporter"/>
         <subcommand clear="true"/>
         <labels>
-          <suse_label_helper:add_prefix prefix="com.suse.caasp.v5">
+          <suse_label_helper:add_prefix prefix="com.suse.caasp.v4.5">
             <label name="org.opencontainers.image.description" value="cert-exporter running on a SLES15 SP2 container guest"/>
             <label name="org.opencontainers.image.title" value="CaaSP cert-exporter container"/>
             <label name="org.opencontainers.image.created" value="%BUILDTIME%"/>
@@ -28,7 +28,7 @@
             <label name="org.opencontainers.image.url" value="https://www.suse.com/products/caas-platform/"/>
             <label name="org.opencontainers.image.version" value="%%PKG_VERSION%%"/>
             <label name="org.openbuildservice.disturl" value="%DISTURL%"/>
-            <label name="com.suse.reference" value="registry.suse.com/caasp/v5/cert-exporter:%%PKG_VERSION%%"/>
+            <label name="com.suse.reference" value="registry.suse.com/caasp/v4.5/cert-exporter:%%PKG_VERSION%%"/>
           </suse_label_helper:add_prefix>
         </labels>
       </containerconfig>

--- a/caasp-cert-manager-cainjector-image/caasp-cert-manager-cainjector-image.kiwi
+++ b/caasp-cert-manager-cainjector-image/caasp-cert-manager-cainjector-image.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<!-- OBS-AddTag: caasp/v5/cert-manager-cainjector:%%PKG_VERSION%%-rev<VERSION> caasp/v5/cert-manager-cainjector:%%PKG_VERSION%%-rev<VERSION>-build<RELEASE> -->
+<!-- OBS-AddTag: caasp/v4.5/cert-manager-cainjector:%%PKG_VERSION%%-rev<VERSION> caasp/v4.5/cert-manager-cainjector:%%PKG_VERSION%%-rev<VERSION>-build<RELEASE> -->
 
 <image schemaversion="6.9" name="caasp-cert-manager-cainjector-image" xmlns:suse_label_helper="com.suse.label_helper">
   <description type="system">
@@ -13,14 +13,14 @@
       image="docker"
       derived_from="obsrepositories:/suse/sle15#15.2">
       <containerconfig
-        name="caasp/v5/cert-manager-cainjector"
+        name="caasp/v4.5/cert-manager-cainjector"
         tag="%%PKG_VERSION%%"
         maintainer="SUSE Containers Team &lt;containers@suse.com&gt;"
         user="nobody">
         <entrypoint execute="/usr/bin/cert-manager-cainjector"/>
         <subcommand clear="true"/>
         <labels>
-          <suse_label_helper:add_prefix prefix="com.suse.caasp.v5">
+          <suse_label_helper:add_prefix prefix="com.suse.caasp.v4.5">
             <label name="org.opencontainers.image.description" value="cert-manager-cainjector running on a SLES15 SP2 container guest"/>
             <label name="org.opencontainers.image.title" value="CaaSP cert-manager-cainjector container"/>
             <label name="org.opencontainers.image.created" value="%BUILDTIME%"/>
@@ -28,7 +28,7 @@
             <label name="org.opencontainers.image.url" value="https://www.suse.com/products/caas-platform/"/>
             <label name="org.opencontainers.image.version" value="%%PKG_VERSION%%"/>
             <label name="org.openbuildservice.disturl" value="%DISTURL%"/>
-            <label name="com.suse.reference" value="registry.suse.com/caasp/v5/cert-manager-cainjector:%%PKG_VERSION%%"/>
+            <label name="com.suse.reference" value="registry.suse.com/caasp/v4.5/cert-manager-cainjector:%%PKG_VERSION%%"/>
           </suse_label_helper:add_prefix>
         </labels>
       </containerconfig>

--- a/caasp-cert-manager-controller-image/caasp-cert-manager-controller-image.kiwi
+++ b/caasp-cert-manager-controller-image/caasp-cert-manager-controller-image.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<!-- OBS-AddTag: caasp/v5/cert-manager-controller:%%PKG_VERSION%%-rev<VERSION> caasp/v5/cert-manager-controller:%%PKG_VERSION%%-rev<VERSION>-build<RELEASE> caasp/v5/cert-manager-controller:beta -->
+<!-- OBS-AddTag: caasp/v4.5/cert-manager-controller:%%PKG_VERSION%%-rev<VERSION> caasp/v4.5/cert-manager-controller:%%PKG_VERSION%%-rev<VERSION>-build<RELEASE> caasp/v4.5/cert-manager-controller:beta -->
 
 <image schemaversion="6.9" name="caasp-cert-manager-controller-image" xmlns:suse_label_helper="com.suse.label_helper">
   <description type="system">
@@ -13,14 +13,14 @@
       image="docker"
       derived_from="obsrepositories:/suse/sle15#15.2">
       <containerconfig
-        name="caasp/v5/cert-manager-controller"
+        name="caasp/v4.5/cert-manager-controller"
         tag="%%PKG_VERSION%%"
         maintainer="SUSE Containers Team &lt;containers@suse.com&gt;"
         user="nobody">
         <entrypoint execute="/usr/bin/cert-manager-controller"/>
         <subcommand clear="true"/>
         <labels>
-          <suse_label_helper:add_prefix prefix="com.suse.caasp.v5">
+          <suse_label_helper:add_prefix prefix="com.suse.caasp.v4.5">
             <label name="org.opencontainers.image.description" value="cert-manager-controller running on a SLES15 SP2 container guest"/>
             <label name="org.opencontainers.image.title" value="CaaSP cert-manager-controller container"/>
             <label name="org.opencontainers.image.created" value="%BUILDTIME%"/>
@@ -28,7 +28,7 @@
             <label name="org.opencontainers.image.url" value="https://www.suse.com/products/caas-platform/"/>
             <label name="org.opencontainers.image.version" value="%%PKG_VERSION%%"/>
             <label name="org.openbuildservice.disturl" value="%DISTURL%"/>
-            <label name="com.suse.reference" value="registry.suse.com/caasp/v5/cert-manager-controller:%%PKG_VERSION%%"/>
+            <label name="com.suse.reference" value="registry.suse.com/caasp/v4.5/cert-manager-controller:%%PKG_VERSION%%"/>
           </suse_label_helper:add_prefix>
         </labels>
       </containerconfig>

--- a/caasp-cert-manager-webhook-image/caasp-cert-manager-webhook-image.kiwi
+++ b/caasp-cert-manager-webhook-image/caasp-cert-manager-webhook-image.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<!-- OBS-AddTag: caasp/v5/cert-manager-webhook:%%PKG_VERSION%%-rev<VERSION> caasp/v5/cert-manager-webhook:%%PKG_VERSION%%-rev<VERSION>-build<RELEASE> caasp/v5/cert-manager-webhook:beta -->
+<!-- OBS-AddTag: caasp/v4.5/cert-manager-webhook:%%PKG_VERSION%%-rev<VERSION> caasp/v4.5/cert-manager-webhook:%%PKG_VERSION%%-rev<VERSION>-build<RELEASE> caasp/v4.5/cert-manager-webhook:beta -->
 
 <image schemaversion="6.9" name="caasp-cert-manager-webhook-image" xmlns:suse_label_helper="com.suse.label_helper">
   <description type="system">
@@ -13,14 +13,14 @@
       image="docker"
       derived_from="obsrepositories:/suse/sle15#15.2">
       <containerconfig
-        name="caasp/v5/cert-manager-webhook"
+        name="caasp/v4.5/cert-manager-webhook"
         tag="%%PKG_VERSION%%"
         maintainer="SUSE Containers Team &lt;containers@suse.com&gt;"
         user="nobody">
         <entrypoint execute="/usr/bin/cert-manager-webhook"/>
         <subcommand clear="true"/>
         <labels>
-          <suse_label_helper:add_prefix prefix="com.suse.caasp.v5">
+          <suse_label_helper:add_prefix prefix="com.suse.caasp.v4.5">
             <label name="org.opencontainers.image.description" value="cert-manager-webhook running on a SLES15 SP2 container guest"/>
             <label name="org.opencontainers.image.title" value="CaaSP cert-manager-webhook container"/>
             <label name="org.opencontainers.image.created" value="%BUILDTIME%"/>
@@ -28,7 +28,7 @@
             <label name="org.opencontainers.image.url" value="https://www.suse.com/products/caas-platform/"/>
             <label name="org.opencontainers.image.version" value="%%PKG_VERSION%%"/>
             <label name="org.openbuildservice.disturl" value="%DISTURL%"/>
-            <label name="com.suse.reference" value="registry.suse.com/caasp/v5/cert-manager-webhook:%%PKG_VERSION%%"/>
+            <label name="com.suse.reference" value="registry.suse.com/caasp/v4.5/cert-manager-webhook:%%PKG_VERSION%%"/>
           </suse_label_helper:add_prefix>
         </labels>
       </containerconfig>

--- a/caasp-cilium-etcd-operator-image/caasp-cilium-etcd-operator-image.kiwi
+++ b/caasp-cilium-etcd-operator-image/caasp-cilium-etcd-operator-image.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<!-- OBS-AddTag: caasp/v5/cilium-etcd-operator:%%PKG_VERSION%%-rev<VERSION> caasp/v5/cilium-etcd-operator:%%PKG_VERSION%%-rev<VERSION>-build<RELEASE> caasp/v5/cilium-etcd-operator:beta -->
+<!-- OBS-AddTag: caasp/v4.5/cilium-etcd-operator:%%PKG_VERSION%%-rev<VERSION> caasp/v4.5/cilium-etcd-operator:%%PKG_VERSION%%-rev<VERSION>-build<RELEASE> caasp/v4.5/cilium-etcd-operator:beta -->
 
 <image schemaversion="6.9" name="caasp-cilium-etcd-operator-image" xmlns:suse_label_helper="com.suse.label_helper">
   <description type="system">
@@ -13,13 +13,13 @@
       image="docker"
       derived_from="obsrepositories:/suse/sle15#15.2">
       <containerconfig
-        name="caasp/v5/cilium-etcd-operator"
+        name="caasp/v4.5/cilium-etcd-operator"
         tag="%%PKG_VERSION%%"
         maintainer="SUSE Containers Team &lt;containers@suse.com&gt;">
         <entrypoint execute="/usr/bin/cilium-etcd-operator"/>
         <subcommand clear="true"/>
         <labels>
-          <suse_label_helper:add_prefix prefix="com.suse.caasp.v5">
+          <suse_label_helper:add_prefix prefix="com.suse.caasp.v4.5">
             <label name="org.opencontainers.image.description" value="cilium-etcd-operator running on an SLES15 SP2 container guest"/>
             <label name="org.opencontainers.image.title" value="Cilium etcd operator container"/>
             <label name="org.opencontainers.image.created" value="%BUILDTIME%"/>
@@ -27,7 +27,7 @@
             <label name="org.opencontainers.image.url" value="https://www.suse.com/products/caas-platform/"/>
             <label name="org.opencontainers.image.version" value="%%PKG_VERSION%%"/>
             <label name="org.openbuildservice.disturl" value="%DISTURL%"/>
-            <label name="com.suse.reference" value="registry.suse.com/caasp/v5/cilium-etcd-operator:%%PKG_VERSION%%"/>
+            <label name="com.suse.reference" value="registry.suse.com/caasp/v4.5/cilium-etcd-operator:%%PKG_VERSION%%"/>
           </suse_label_helper:add_prefix>
         </labels>
       </containerconfig>

--- a/caasp-cilium-image/caasp-cilium-image.kiwi
+++ b/caasp-cilium-image/caasp-cilium-image.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<!-- OBS-AddTag: caasp/v5/cilium:%%PKG_VERSION%%-rev<VERSION> caasp/v5/cilium:%%PKG_VERSION%%-rev<VERSION>-build<RELEASE> caasp/v5/cilium:beta -->
+<!-- OBS-AddTag: caasp/v4.5/cilium:%%PKG_VERSION%%-rev<VERSION> caasp/v4.5/cilium:%%PKG_VERSION%%-rev<VERSION>-build<RELEASE> caasp/v4.5/cilium:beta -->
 
 <image schemaversion="6.9" name="caasp-cilium-image" xmlns:suse_label_helper="com.suse.label_helper">
   <description type="system">
@@ -13,21 +13,21 @@
       image="docker"
       derived_from="obsrepositories:/suse/sle15#15.2">
       <containerconfig
-        name="caasp/v5/cilium"
+        name="caasp/v4.5/cilium"
         tag="%%PKG_VERSION%%"
         maintainer="SUSE Containers Team &lt;containers@suse.com&gt;">
         <entrypoint execute="/usr/bin/cilium-agent"/>
         <subcommand clear="true"/>
         <labels>
-          <suse_label_helper:add_prefix prefix="com.suse.caasp.v5">
-            <label name="com.suse.caasp.v5.description" value="Cilium running on an SLES15 SP2 container guest"/>
-            <label name="com.suse.caasp.v5.title" value="Cilium container"/>
+          <suse_label_helper:add_prefix prefix="com.suse.caasp.v4.5">
+            <label name="com.suse.caasp.v4.5.description" value="Cilium running on an SLES15 SP2 container guest"/>
+            <label name="com.suse.caasp.v4.5.title" value="Cilium container"/>
             <label name="org.opencontainers.image.created" value="%BUILDTIME%"/>
             <label name="org.opencontainers.image.vendor" value="SUSE LLC"/>
             <label name="org.opencontainers.image.url" value="https://www.suse.com/products/caas-platform/"/>
             <label name="org.opencontainers.image.version" value="%%PKG_VERSION%%"/>
             <label name="org.openbuildservice.disturl" value="%DISTURL%"/>
-            <label name="com.suse.reference" value="registry.suse.com/caasp/v5/cilium:%%PKG_VERSION%%"/>
+            <label name="com.suse.reference" value="registry.suse.com/caasp/v4.5/cilium:%%PKG_VERSION%%"/>
           </suse_label_helper:add_prefix>
         </labels>
       </containerconfig>

--- a/caasp-cilium-operator-image/caasp-cilium-operator-image.kiwi
+++ b/caasp-cilium-operator-image/caasp-cilium-operator-image.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<!-- OBS-AddTag: caasp/v5/cilium-operator:%%PKG_VERSION%%-rev<VERSION> caasp/v5/cilium-operator:%%PKG_VERSION%%-rev<VERSION>-build<RELEASE> caasp/v5/cilium-operator:beta -->
+<!-- OBS-AddTag: caasp/v4.5/cilium-operator:%%PKG_VERSION%%-rev<VERSION> caasp/v4.5/cilium-operator:%%PKG_VERSION%%-rev<VERSION>-build<RELEASE> caasp/v4.5/cilium-operator:beta -->
 
 <image schemaversion="6.9" name="caasp-cilium-operator-image" xmlns:suse_label_helper="com.suse.label_helper">
   <description type="system">
@@ -13,14 +13,14 @@
       image="docker"
       derived_from="obsrepositories:/suse/sle15#15.2">
       <containerconfig
-        name="caasp/v5/cilium-operator"
+        name="caasp/v4.5/cilium-operator"
         tag="%%PKG_VERSION%%"
 	    maintainer="SUSE Containers Team &lt;containers@suse.com&gt;">
         <entrypoint execute="/usr/bin/cilium-operator"/>
         <subcommand clear="true"/>
         <history author="Nirmoy Das &lt;ndas@suse.de&gt;">cilium-operator Container</history>
         <labels>
-          <suse_label_helper:add_prefix prefix="com.suse.caasp.v5">  
+          <suse_label_helper:add_prefix prefix="com.suse.caasp.v4.5">  
             <label name="org.opencontainers.image.description" value="Cilium operator running on an SLES15 SP2 container guest"/>
             <label name="org.opencontainers.image.title" value="Cilium operator container"/>
             <label name="org.opencontainers.image.created" value="%BUILDTIME%"/>
@@ -28,7 +28,7 @@
             <label name="org.opencontainers.image.url" value="https://www.suse.com/products/caas-platform/"/>
             <label name="org.opencontainers.image.version" value="%%PKG_VERSION%%"/>
             <label name="org.openbuildservice.disturl" value="%DISTURL%"/>
-            <label name="com.suse.reference" value="registry.suse.com/caasp/v5/cilium-operator:%%PKG_VERSION%%"/>
+            <label name="com.suse.reference" value="registry.suse.com/caasp/v4.5/cilium-operator:%%PKG_VERSION%%"/>
           </suse_label_helper:add_prefix>
         </labels>
       </containerconfig>

--- a/caasp-cloud-provider-openstack-image/caasp-cloud-provider-openstack-image.kiwi
+++ b/caasp-cloud-provider-openstack-image/caasp-cloud-provider-openstack-image.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<!-- OBS-AddTag: caasp/v5/cloud-provider-openstack:%%PKG_VERSION%%-rev<VERSION> caasp/v5/cloud-provider-openstack:%%PKG_VERSION%%-rev<VERSION>-build<RELEASE> caasp/v5/cloud-provider-openstack:beta -->
+<!-- OBS-AddTag: caasp/v4.5/cloud-provider-openstack:%%PKG_VERSION%%-rev<VERSION> caasp/v4.5/cloud-provider-openstack:%%PKG_VERSION%%-rev<VERSION>-build<RELEASE> caasp/v4.5/cloud-provider-openstack:beta -->
 
 <image schemaversion="6.9" name="caasp-cloud-provider-openstack-image" xmlns:suse_label_helper="com.suse.label_helper">
   <description type="system">
@@ -13,13 +13,13 @@
       image="docker"
       derived_from="obsrepositories:/suse/sle15#15.2">
       <containerconfig
-        name="caasp/v5/cloud-provider-openstack"
+        name="caasp/v4.5/cloud-provider-openstack"
         tag="%%PKG_VERSION%%"
         maintainer="SUSE Containers Team &lt;containers@suse.com&gt;">
         <entrypoint execute="/usr/bin/openstack-cloud-controller-manager"/>
         <subcommand clear="true"/>
         <labels>
-          <suse_label_helper:add_prefix prefix="com.suse.caasp.v5">
+          <suse_label_helper:add_prefix prefix="com.suse.caasp.v4.5">
             <label name="org.opencontainers.image.description" value="OpenStack cloud controller manager running on an SLES15 container guest"/>
             <label name="org.opencontainers.image.title" value="OpenStack cloud provider container"/>
             <label name="org.opencontainers.image.created" value="%BUILDTIME%"/>
@@ -27,7 +27,7 @@
             <label name="org.opencontainers.image.url" value="https://www.suse.com/products/caas-platform/"/>
             <label name="org.opencontainers.image.version" value="%%PKG_VERSION%%"/>
             <label name="org.openbuildservice.disturl" value="%DISTURL%"/>
-            <label name="com.suse.reference" value="registry.suse.com/caasp/v5/cloud-provider-openstack:%%PKG_VERSION%%"/>
+            <label name="com.suse.reference" value="registry.suse.com/caasp/v4.5/cloud-provider-openstack:%%PKG_VERSION%%"/>
           </suse_label_helper:add_prefix>
         </labels>
       </containerconfig>

--- a/caasp-configmap-reload-image/caasp-configmap-reload-image.kiwi
+++ b/caasp-configmap-reload-image/caasp-configmap-reload-image.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<!-- OBS-AddTag: caasp/v5/configmap-reload:%%PKG_VERSION%%-rev<VERSION> caasp/v5/configmap-reload:%%PKG_VERSION%%-rev<VERSION>-build<RELEASE> caasp/v5/configmap-reload:beta -->
+<!-- OBS-AddTag: caasp/v4.5/configmap-reload:%%PKG_VERSION%%-rev<VERSION> caasp/v4.5/configmap-reload:%%PKG_VERSION%%-rev<VERSION>-build<RELEASE> caasp/v4.5/configmap-reload:beta -->
 
 <image schemaversion="6.9" name="caasp-configmap-reload-image" xmlns:suse_label_helper="com.suse.label_helper">
   <description type="system">
@@ -13,13 +13,13 @@
       image="docker"
       derived_from="obsrepositories:/suse/sle15#15.2">
       <containerconfig
-        name="caasp/v5/configmap-reload"
+        name="caasp/v4.5/configmap-reload"
         tag="%%PKG_VERSION%%"
         maintainer="SUSE Containers Team &lt;containers@suse.com&gt;">
         <entrypoint execute="/usr/bin/configmap-reload"/>
         <subcommand clear="true"/>
         <labels>
-          <suse_label_helper:add_prefix prefix="com.suse.caasp.v5">
+          <suse_label_helper:add_prefix prefix="com.suse.caasp.v4.5">
             <label name="org.opencontainers.image.description" value="Prometheus configmap-reload running on a SLES15 SP2 container guest"/>
             <label name="org.opencontainers.image.title" value="CaaSP Prometheus configmap-reload container"/>
             <label name="org.opencontainers.image.created" value="%BUILDTIME%"/>
@@ -27,7 +27,7 @@
             <label name="org.opencontainers.image.url" value="https://www.suse.com/products/caas-platform/"/>
             <label name="org.opencontainers.image.version" value="%%PKG_VERSION%%"/>
             <label name="org.openbuildservice.disturl" value="%DISTURL%"/>
-            <label name="com.suse.reference" value="registry.suse.com/caasp/v5/configmap-reload:%%PKG_VERSION%%"/>
+            <label name="com.suse.reference" value="registry.suse.com/caasp/v4.5/configmap-reload:%%PKG_VERSION%%"/>
           </suse_label_helper:add_prefix>
         </labels>
       </containerconfig>

--- a/caasp-coredns-image/caasp-coredns-image.kiwi
+++ b/caasp-coredns-image/caasp-coredns-image.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<!-- OBS-AddTag: caasp/v5/coredns:%%PKG_VERSION%%-rev<VERSION> caasp/v5/coredns:%%PKG_VERSION%%-rev<VERSION>-build<RELEASE> caasp/v5/coredns:beta -->
+<!-- OBS-AddTag: caasp/v4.5/coredns:%%PKG_VERSION%%-rev<VERSION> caasp/v4.5/coredns:%%PKG_VERSION%%-rev<VERSION>-build<RELEASE> caasp/v4.5/coredns:beta -->
 
 <image schemaversion="6.9" name="caasp-coredns-image" xmlns:suse_label_helper="com.suse.label_helper">
   <description type="system">
@@ -13,7 +13,7 @@
       image="docker"
       derived_from="obsrepositories:/suse/sle15#15.2">
       <containerconfig
-        name="caasp/v5/coredns"
+        name="caasp/v4.5/coredns"
         tag="%%PKG_VERSION%%"
         maintainer="SUSE Containers Team &lt;containers@suse.com&gt;">
         <expose>
@@ -23,7 +23,7 @@
         <entrypoint execute="/usr/sbin/coredns"/>
         <subcommand clear="true"/>
         <labels>
-          <suse_label_helper:add_prefix prefix="com.suse.caasp.v5">
+          <suse_label_helper:add_prefix prefix="com.suse.caasp.v4.5">
             <label name="org.opencontainers.image.description" value="coredns running on a SLES15 SP2 container guest"/>
             <label name="org.opencontainers.image.title" value="CaaSP CoreDNS container"/>
             <label name="org.opencontainers.image.created" value="%BUILDTIME%"/>
@@ -31,7 +31,7 @@
             <label name="org.opencontainers.image.url" value="https://www.suse.com/products/caas-platform/"/>
             <label name="org.opencontainers.image.version" value="%%PKG_VERSION%%"/>
             <label name="org.openbuildservice.disturl" value="%DISTURL%"/>
-            <label name="com.suse.reference" value="registry.suse.com/caasp/v5/coredns:%%PKG_VERSION%%"/>
+            <label name="com.suse.reference" value="registry.suse.com/caasp/v4.5/coredns:%%PKG_VERSION%%"/>
           </suse_label_helper:add_prefix>
         </labels>
       </containerconfig>

--- a/caasp-curl-image/caasp-curl-image.kiwi
+++ b/caasp-curl-image/caasp-curl-image.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<!-- OBS-AddTag: caasp/v5/curl:%%PKG_VERSION%%-rev<VERSION> caasp/v5/curl:%%PKG_VERSION%%-rev<VERSION>-build<RELEASE> caasp/v5/curl:beta -->
+<!-- OBS-AddTag: caasp/v4.5/curl:%%PKG_VERSION%%-rev<VERSION> caasp/v4.5/curl:%%PKG_VERSION%%-rev<VERSION>-build<RELEASE> caasp/v4.5/curl:beta -->
 
 <image schemaversion="6.9" name="caasp-curl-image" xmlns:suse_label_helper="com.suse.label_helper">
   <description type="system">
@@ -13,14 +13,14 @@
       image="docker"
       derived_from="obsrepositories:/suse/sle15#15.2">
       <containerconfig
-        name="caasp/v5/curl"
+        name="caasp/v4.5/curl"
         tag="%%PKG_VERSION%%"
         maintainer="SUSE Containers Team &lt;containers@suse.com&gt;"
         user="nobody">
         <entrypoint execute="curl"/>
         <subcommand clear="true"/>
         <labels>
-          <suse_label_helper:add_prefix prefix="com.suse.caasp.v5">
+          <suse_label_helper:add_prefix prefix="com.suse.caasp.v4.5">
             <label name="org.opencontainers.image.description" value="curl running on a SLES15 SP2 container guest"/>
             <label name="org.opencontainers.image.title" value="CaaSP curl container"/>
             <label name="org.opencontainers.image.created" value="%BUILDTIME%"/>
@@ -28,7 +28,7 @@
             <label name="org.opencontainers.image.url" value="https://www.suse.com/products/caas-platform/"/>
             <label name="org.opencontainers.image.version" value="%%PKG_VERSION%%"/>
             <label name="org.openbuildservice.disturl" value="%DISTURL%"/>
-            <label name="com.suse.reference" value="registry.suse.com/caasp/v5/curl:%%PKG_VERSION%%"/>
+            <label name="com.suse.reference" value="registry.suse.com/caasp/v4.5/curl:%%PKG_VERSION%%"/>
           </suse_label_helper:add_prefix>
         </labels>
       </containerconfig>

--- a/caasp-default-http-backend-image/caasp-default-http-backend-image.kiwi
+++ b/caasp-default-http-backend-image/caasp-default-http-backend-image.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<!-- OBS-AddTag: caasp/v5/default-http-backend:%%PKG_VERSION%%-rev<VERSION> caasp/v5/default-http-backend:%%PKG_VERSION%%-rev<VERSION>-build<RELEASE> caasp/v5/default-http-backend:beta -->
+<!-- OBS-AddTag: caasp/v4.5/default-http-backend:%%PKG_VERSION%%-rev<VERSION> caasp/v4.5/default-http-backend:%%PKG_VERSION%%-rev<VERSION>-build<RELEASE> caasp/v4.5/default-http-backend:beta -->
 
 <image schemaversion="6.9" name="caasp-default-http-backend-image" xmlns:suse_label_helper="com.suse.label_helper">
   <description type="system">
@@ -13,21 +13,21 @@
       image="docker"
       derived_from="obsrepositories:/suse/sle15#15.2">
       <containerconfig
-        name="caasp/v5/default-http-backend"
+        name="caasp/v4.5/default-http-backend"
         tag="%%PKG_VERSION%%"
         maintainer="SUSE Containers Team &lt;containers@suse.com&gt;">
         <entrypoint execute="/usr/bin/kubernetes-404-server"/>
         <subcommand clear="true"/>
         <labels>
-          <suse_label_helper:add_prefix prefix="com.suse.caasp.v5">
-            <label name="com.suse.caasp.v5.description" value="Kubernetes-404-server running on an SLES15 SP2 container guest"/>
-            <label name="com.suse.caasp.v5.title" value="default-http-backend container"/>
+          <suse_label_helper:add_prefix prefix="com.suse.caasp.v4.5">
+            <label name="com.suse.caasp.v4.5.description" value="Kubernetes-404-server running on an SLES15 SP2 container guest"/>
+            <label name="com.suse.caasp.v4.5.title" value="default-http-backend container"/>
             <label name="org.opencontainers.image.created" value="%BUILDTIME%"/>
             <label name="org.opencontainers.image.vendor" value="SUSE LLC"/>
             <label name="org.opencontainers.image.url" value="https://www.suse.com/products/caas-platform/"/>
             <label name="org.opencontainers.image.version" value="%%PKG_VERSION%%"/>
             <label name="org.openbuildservice.disturl" value="%DISTURL%"/>
-            <label name="com.suse.reference" value="registry.suse.com/caasp/v5/default-http-backend:%%PKG_VERSION%%"/>
+            <label name="com.suse.reference" value="registry.suse.com/caasp/v4.5/default-http-backend:%%PKG_VERSION%%"/>
           </suse_label_helper:add_prefix>
         </labels>
       </containerconfig> 

--- a/caasp-etcd-image/caasp-etcd-image.kiwi
+++ b/caasp-etcd-image/caasp-etcd-image.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<!-- OBS-AddTag: caasp/v5/etcd:%%PKG_VERSION%%-rev<VERSION> caasp/v5/etcd:%%PKG_VERSION%%-rev<VERSION>-build<RELEASE> caasp/v5/etcd:beta -->
+<!-- OBS-AddTag: caasp/v4.5/etcd:%%PKG_VERSION%%-rev<VERSION> caasp/v4.5/etcd:%%PKG_VERSION%%-rev<VERSION>-build<RELEASE> caasp/v4.5/etcd:beta -->
 
 <image schemaversion="6.9" name="caasp-etcd-image" xmlns:suse_label_helper="com.suse.label_helper">
   <description type="system">
@@ -13,7 +13,7 @@
       image="docker"
       derived_from="obsrepositories:/suse/sle15#15.2">
       <containerconfig
-        name="caasp/v5/etcd"
+        name="caasp/v4.5/etcd"
         tag="%%PKG_VERSION%%"
         maintainer="SUSE Containers Team &lt;containers@suse.com&gt;">
         <expose>
@@ -30,7 +30,7 @@
         </environment>
         <subcommand clear="true"/>
         <labels>
-          <suse_label_helper:add_prefix prefix="com.suse.caasp.v5">
+          <suse_label_helper:add_prefix prefix="com.suse.caasp.v4.5">
             <label name="org.opencontainers.image.description" value="etcd running on a SLES15 SP2 container guest"/>
             <label name="org.opencontainers.image.title" value="CaaSP etcd container"/>
             <label name="org.opencontainers.image.created" value="%BUILDTIME%"/>
@@ -38,7 +38,7 @@
             <label name="org.opencontainers.image.url" value="https://www.suse.com/products/caas-platform/"/>
             <label name="org.opencontainers.image.version" value="%%PKG_VERSION%%"/>
             <label name="org.openbuildservice.disturl" value="%DISTURL%"/>
-            <label name="com.suse.reference" value="registry.suse.com/caasp/v5/etcd:%%PKG_VERSION%%"/>
+            <label name="com.suse.reference" value="registry.suse.com/caasp/v4.5/etcd:%%PKG_VERSION%%"/>
           </suse_label_helper:add_prefix>
         </labels>
       </containerconfig>

--- a/caasp-gangway-image/caasp-gangway-image.kiwi
+++ b/caasp-gangway-image/caasp-gangway-image.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<!-- OBS-AddTag: caasp/v5/gangway:%%PKG_VERSION%%-rev<VERSION> caasp/v5/gangway:%%PKG_VERSION%%-rev<VERSION>-build<RELEASE> caasp/v5/gangway:beta -->
+<!-- OBS-AddTag: caasp/v4.5/gangway:%%PKG_VERSION%%-rev<VERSION> caasp/v4.5/gangway:%%PKG_VERSION%%-rev<VERSION>-build<RELEASE> caasp/v4.5/gangway:beta -->
 
 <image schemaversion="6.9" name="caasp-gangway-image" xmlns:suse_label_helper="com.suse.label_helper">
   <description type="system">
@@ -13,13 +13,13 @@
       image="docker"
       derived_from="obsrepositories:/suse/sle15#15.2">
       <containerconfig
-        name="caasp/v5/gangway"
+        name="caasp/v4.5/gangway"
         tag="%%PKG_VERSION%%"
         maintainer="SUSE Containers Team &lt;containers@suse.com&gt;">
         <entrypoint execute="/usr/bin/gangway"/>
         <subcommand clear="true"/>
         <labels>
-          <suse_label_helper:add_prefix prefix="com.suse.caasp.v5">
+          <suse_label_helper:add_prefix prefix="com.suse.caasp.v4.5">
             <label name="org.opencontainers.image.description" value="Image containing gangway for CaaSP"/>
             <label name="org.opencontainers.image.title" value="CaaSP gangway container"/>
             <label name="org.opencontainers.image.created" value="%BUILDTIME%"/>
@@ -27,7 +27,7 @@
             <label name="org.opencontainers.image.url" value="https://www.suse.com/products/caas-platform/"/>
             <label name="org.opencontainers.image.version" value="%%PKG_VERSION%%"/>
             <label name="org.openbuildservice.disturl" value="%DISTURL%"/>
-            <label name="com.suse.reference" value="registry.suse.com/caasp/v5/gangway:%%PKG_VERSION%%"/>
+            <label name="com.suse.reference" value="registry.suse.com/caasp/v4.5/gangway:%%PKG_VERSION%%"/>
           </suse_label_helper:add_prefix>
         </labels>
       </containerconfig>

--- a/caasp-grafana-image/caasp-grafana-image.kiwi
+++ b/caasp-grafana-image/caasp-grafana-image.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<!-- OBS-AddTag: caasp/v5/grafana:%%PKG_VERSION%%-rev<VERSION> caasp/v5/grafana:%%PKG_VERSION%%-rev<VERSION>-build<RELEASE> caasp/v5/grafana:beta -->
+<!-- OBS-AddTag: caasp/v4.5/grafana:%%PKG_VERSION%%-rev<VERSION> caasp/v4.5/grafana:%%PKG_VERSION%%-rev<VERSION>-build<RELEASE> caasp/v4.5/grafana:beta -->
 
 <image schemaversion="6.9" name="caasp-grafana-image" xmlns:suse_label_helper="com.suse.label_helper">
   <description type="system">
@@ -13,7 +13,7 @@
       image="docker"
       derived_from="obsrepositories:/suse/sle15#15.2">
       <containerconfig
-        name="caasp/v5/grafana"
+        name="caasp/v4.5/grafana"
         tag="%%PKG_VERSION%%"
         maintainer="SUSE Containers Team &lt;containers@suse.com&gt;">
         <expose>
@@ -24,7 +24,7 @@
         </entrypoint>
         <subcommand clear="true"/>
         <labels>
-          <suse_label_helper:add_prefix prefix="com.suse.caasp.v5">
+          <suse_label_helper:add_prefix prefix="com.suse.caasp.v4.5">
             <label name="org.opencontainers.image.description" value="grafana running on a SLES15 SP2 container guest"/>
             <label name="org.opencontainers.image.title" value="CaaSP Grafana container"/>
             <label name="org.opencontainers.image.created" value="%BUILDTIME%"/>
@@ -32,7 +32,7 @@
             <label name="org.opencontainers.image.url" value="https://www.suse.com/products/caas-platform/"/>
             <label name="org.opencontainers.image.version" value="%%PKG_VERSION%%"/>
             <label name="org.openbuildservice.disturl" value="%DISTURL%"/>
-            <label name="com.suse.reference" value="registry.suse.com/caasp/v5/grafana:%%PKG_VERSION%%"/>
+            <label name="com.suse.reference" value="registry.suse.com/caasp/v4.5/grafana:%%PKG_VERSION%%"/>
           </suse_label_helper:add_prefix>
         </labels>
       </containerconfig>

--- a/caasp-helm-tiller-image/caasp-helm-tiller-image.kiwi
+++ b/caasp-helm-tiller-image/caasp-helm-tiller-image.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<!-- OBS-AddTag: caasp/v5/helm-tiller:%%PKG_VERSION%%-rev<VERSION> caasp/v5/helm-tiller:%%PKG_VERSION%%-rev<VERSION>-build<RELEASE> caasp/v5/helm-tiller:beta -->
+<!-- OBS-AddTag: caasp/v4.5/helm-tiller:%%PKG_VERSION%%-rev<VERSION> caasp/v4.5/helm-tiller:%%PKG_VERSION%%-rev<VERSION>-build<RELEASE> caasp/v4.5/helm-tiller:beta -->
 
 <image schemaversion="6.9" name="caasp-helm-tiller-image" xmlns:suse_label_helper="com.suse.label_helper">
   <description type="system">
@@ -13,14 +13,14 @@
       image="docker"
       derived_from="obsrepositories:/suse/sle15#15.2">
       <containerconfig
-        name="caasp/v5/helm-tiller"
+        name="caasp/v4.5/helm-tiller"
         tag="%%PKG_VERSION%%"
         maintainer="SUSE Containers Team &lt;containers@suse.com&gt;"
         user="nobody">
         <entrypoint execute="/usr/bin/tiller"/>
         <subcommand clear="true"/>
         <labels>
-          <suse_label_helper:add_prefix prefix="com.suse.caasp.v5">
+          <suse_label_helper:add_prefix prefix="com.suse.caasp.v4.5">
             <label name="org.opencontainers.image.description" value="Helm tiller running on an SLE15 SP2 container guest"/>
             <label name="org.opencontainers.image.title" value="CaaSP helm tiller container"/>
             <label name="org.opencontainers.image.created" value="%BUILDTIME%"/>
@@ -28,7 +28,7 @@
             <label name="org.opencontainers.image.url" value="https://www.suse.com/products/caas-platform/"/>
             <label name="org.opencontainers.image.version" value="%%PKG_VERSION%%"/>
             <label name="org.openbuildservice.disturl" value="%DISTURL%"/>
-            <label name="com.suse.reference" value="registry.suse.com/caasp/v5/helm-tiller:%%PKG_VERSION%%"/>
+            <label name="com.suse.reference" value="registry.suse.com/caasp/v4.5/helm-tiller:%%PKG_VERSION%%"/>
           </suse_label_helper:add_prefix>
         </labels>
       </containerconfig>

--- a/caasp-ingress-nginx-controller-image/caasp-ingress-nginx-controller-image.kiwi
+++ b/caasp-ingress-nginx-controller-image/caasp-ingress-nginx-controller-image.kiwi
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- OBS-AddTag: caasp/v5/ingress-nginx-controller:%%PKG_VERSION%%-rev<VERSION> caasp/v5/ingress-nginx-controller:%%PKG_VERSION%%-rev<VERSION>-build<RELEASE> caasp/v5/ingress-nginx-controller:beta -->
+<!-- OBS-AddTag: caasp/v4.5/ingress-nginx-controller:%%PKG_VERSION%%-rev<VERSION> caasp/v4.5/ingress-nginx-controller:%%PKG_VERSION%%-rev<VERSION>-build<RELEASE> caasp/v4.5/ingress-nginx-controller:beta -->
 <image xmlns:suse_label_helper="com.suse.label_helper" schemaversion="6.9" name="ingress-nginx-controller">
   <description type="system">
     <author>SUSE Containers Team</author>
@@ -11,15 +11,15 @@
       <containerconfig name="ingress-nginx-controller" tag="0.15.0" maintainer="SUSE Containers Team &lt;containers@suse.com&gt;">
         <entrypoint execute="/usr/bin/ingress-nginx-controller"/>
         <labels>
-          <suse_label_helper:add_prefix prefix="com.suse.caasp.v5">
-            <label name="com.suse.caasp.v5.description" value="ingress-nginx running on an SLES15 SP2 container guest"/>
-            <label name="com.suse.caasp.v5.title" value="ingress-nginx container"/>
+          <suse_label_helper:add_prefix prefix="com.suse.caasp.v4.5">
+            <label name="com.suse.caasp.v4.5.description" value="ingress-nginx running on an SLES15 SP2 container guest"/>
+            <label name="com.suse.caasp.v4.5.title" value="ingress-nginx container"/>
             <label name="org.opencontainers.image.created" value="%BUILDTIME%"/>
             <label name="org.opencontainers.image.vendor" value="SUSE LLC"/>
             <label name="org.opencontainers.image.url" value="https://www.suse.com/products/caas-platform/"/>
             <label name="org.opencontainers.image.version" value="%%PKG_VERSION%%"/>
             <label name="org.openbuildservice.disturl" value="%DISTURL%"/>
-            <label name="com.suse.reference" value="registry.suse.com/caasp/v5/ingress-nginx:%%PKG_VERSION%%"/>
+            <label name="com.suse.reference" value="registry.suse.com/caasp/v4.5/ingress-nginx:%%PKG_VERSION%%"/>
           </suse_label_helper:add_prefix>
         </labels>
       </containerconfig>

--- a/caasp-istio-base-image/caasp-istio-base-image.kiwi
+++ b/caasp-istio-base-image/caasp-istio-base-image.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<!-- OBS-AddTag: caasp/v5/istio-base:%%PKG_VERSION%%-rev<VERSION> caasp/v5/istio-base:%%PKG_VERSION%%-rev<VERSION>-build<RELEASE> caasp/v5/istio-base:beta -->
+<!-- OBS-AddTag: caasp/v4.5/istio-base:%%PKG_VERSION%%-rev<VERSION> caasp/v4.5/istio-base:%%PKG_VERSION%%-rev<VERSION>-build<RELEASE> caasp/v4.5/istio-base:beta -->
 
 <image schemaversion="6.9" name="caasp-istio-base-image" xmlns:suse_label_helper="com.suse.label_helper">
   <description type="system">
@@ -13,20 +13,20 @@
       image="docker"
       derived_from="obsrepositories:/suse/sle15#15.2">
       <containerconfig
-        name="caasp/v5/istio-base"
+        name="caasp/v4.5/istio-base"
         tag="%%PKG_VERSION%%"
         maintainer="SUSE Containers Team &lt;containers@suse.com&gt;">
         <subcommand clear="true"/>
         <labels>
-          <suse_label_helper:add_prefix prefix="com.suse.caasp.v5">
-            <label name="com.suse.caasp.v5.description" value="Istio base image built on SLES15 SP2"/>
-            <label name="com.suse.caasp.v5.title" value="Istio Base container"/>
+          <suse_label_helper:add_prefix prefix="com.suse.caasp.v4.5">
+            <label name="com.suse.caasp.v4.5.description" value="Istio base image built on SLES15 SP2"/>
+            <label name="com.suse.caasp.v4.5.title" value="Istio Base container"/>
             <label name="org.opencontainers.image.created" value="%BUILDTIME%"/>
             <label name="org.opencontainers.image.vendor" value="SUSE LLC"/>
             <label name="org.opencontainers.image.url" value="https://www.suse.com/products/caas-platform/"/>
             <label name="org.opencontainers.image.version" value="%%PKG_VERSION%%"/>
             <label name="org.openbuildservice.disturl" value="%DISTURL%"/>
-            <label name="com.suse.reference" value="registry.suse.com/caasp/v5/istio-base:%%PKG_VERSION%%"/>
+            <label name="com.suse.reference" value="registry.suse.com/caasp/v4.5/istio-base:%%PKG_VERSION%%"/>
           </suse_label_helper:add_prefix>
         </labels>
       </containerconfig>

--- a/caasp-istio-pilot-image/caasp-istio-pilot-image.kiwi
+++ b/caasp-istio-pilot-image/caasp-istio-pilot-image.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<!-- OBS-AddTag: caasp/v5/istio-pilot:%%PKG_VERSION%%-rev<VERSION> caasp/v5/istio-pilot:%%PKG_VERSION%%-rev<VERSION>-build<RELEASE> caasp/v5/istio-pilot:beta -->
+<!-- OBS-AddTag: caasp/v4.5/istio-pilot:%%PKG_VERSION%%-rev<VERSION> caasp/v4.5/istio-pilot:%%PKG_VERSION%%-rev<VERSION>-build<RELEASE> caasp/v4.5/istio-pilot:beta -->
 
 <image schemaversion="6.9" name="caasp-istio-pilot-image" xmlns:suse_label_helper="com.suse.label_helper">
   <description type="system">
@@ -11,23 +11,23 @@
   <preferences>
     <type
       image="docker"
-	    derived_from="obsrepositories:/caasp/v5/istio-base#1.5.4">
+	    derived_from="obsrepositories:/caasp/v4.5/istio-base#1.5.4">
       <containerconfig
-        name="caasp/v5/istio-pilot"
+        name="caasp/v4.5/istio-pilot"
         tag="%%PKG_VERSION%%"
         maintainer="SUSE Containers Team &lt;containers@suse.com&gt;">
       <entrypoint execute="/usr/bin/pilot-discovery"/>
         <subcommand clear="true"/>
         <labels>
-          <suse_label_helper:add_prefix prefix="com.suse.caasp.v5">
-            <label name="com.suse.caasp.v5.description" value="Istio Pilot running on an SLES15 SP2 container guest"/>
-            <label name="com.suse.caasp.v5.title" value="Istio Pilot container"/>
+          <suse_label_helper:add_prefix prefix="com.suse.caasp.v4.5">
+            <label name="com.suse.caasp.v4.5.description" value="Istio Pilot running on an SLES15 SP2 container guest"/>
+            <label name="com.suse.caasp.v4.5.title" value="Istio Pilot container"/>
             <label name="org.opencontainers.image.created" value="%BUILDTIME%"/>
             <label name="org.opencontainers.image.vendor" value="SUSE LLC"/>
             <label name="org.opencontainers.image.url" value="https://www.suse.com/products/caas-platform/"/>
             <label name="org.opencontainers.image.version" value="%%PKG_VERSION%%"/>
             <label name="org.openbuildservice.disturl" value="%DISTURL%"/>
-            <label name="com.suse.reference" value="registry.suse.com/caasp/v5/istio-pilot:%%PKG_VERSION%%"/>
+            <label name="com.suse.reference" value="registry.suse.com/caasp/v4.5/istio-pilot:%%PKG_VERSION%%"/>
           </suse_label_helper:add_prefix>
         </labels>
       </containerconfig>

--- a/caasp-istio-proxyv2-image/caasp-istio-proxyv2-image.kiwi
+++ b/caasp-istio-proxyv2-image/caasp-istio-proxyv2-image.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<!-- OBS-AddTag: caasp/v5/istio-proxyv2:%%PKG_VERSION%%-rev<VERSION> caasp/v5/istio-proxyv2:%%PKG_VERSION%%-rev<VERSION>-build caasp/v5/istio-proxyv2:beta -->
+<!-- OBS-AddTag: caasp/v4.5/istio-proxyv2:%%PKG_VERSION%%-rev<VERSION> caasp/v4.5/istio-proxyv2:%%PKG_VERSION%%-rev<VERSION>-build caasp/v4.5/istio-proxyv2:beta -->
 
 <image schemaversion="6.9" name="caasp-istio-proxyv2-image" xmlns:suse_label_helper="com.suse.label_helper">
   <description type="system">
@@ -11,23 +11,23 @@
   <preferences>
     <type
       image="docker"
-      derived_from="obsrepositories:/caasp/v5/istio-base#1.5.4">
+      derived_from="obsrepositories:/caasp/v4.5/istio-base#1.5.4">
       <containerconfig
-        name="caasp/v5/istio-proxyv2"
+        name="caasp/v4.5/istio-proxyv2"
         tag="%%PKG_VERSION%%"
         maintainer="SUSE Containers Team &lt;containers@suse.com&gt;">
         <entrypoint execute="/usr/local/bin/pilot-agent"/>
         <subcommand clear="true"/>
         <labels>
-          <suse_label_helper:add_prefix prefix="com.suse.caasp.v5">
-            <label name="com.suse.caasp.v5.description" value="Istio Pilot running on an SLES15 SP2 container guest"/>
-            <label name="com.suse.caasp.v5.title" value="Istio Proxy container"/>
+          <suse_label_helper:add_prefix prefix="com.suse.caasp.v4.5">
+            <label name="com.suse.caasp.v4.5.description" value="Istio Pilot running on an SLES15 SP2 container guest"/>
+            <label name="com.suse.caasp.v4.5.title" value="Istio Proxy container"/>
             <label name="org.opencontainers.image.created" value="%BUILDTIME%"/>
             <label name="org.opencontainers.image.vendor" value="SUSE LLC"/>
             <label name="org.opencontainers.image.url" value="https://www.suse.com/products/caas-platform/"/>
             <label name="org.opencontainers.image.version" value="%%PKG_VERSION%%"/>
             <label name="org.openbuildservice.disturl" value="%DISTURL%"/>
-            <label name="com.suse.reference" value="registry.suse.com/caasp/v5/istio-proxyv2:%%PKG_VERSION%%"/>
+            <label name="com.suse.reference" value="registry.suse.com/caasp/v4.5/istio-proxyv2:%%PKG_VERSION%%"/>
           </suse_label_helper:add_prefix>
         </labels>
         <environment>

--- a/caasp-k8s-sidecar-image/caasp-k8s-sidecar-image.kiwi
+++ b/caasp-k8s-sidecar-image/caasp-k8s-sidecar-image.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<!-- OBS-AddTag: caasp/v5/k8s-sidecar:%%PKG_VERSION%%-rev<VERSION> caasp/v5/k8s-sidecar:%%PKG_VERSION%%-rev<VERSION>-build<RELEASE> caasp/v5/k8s-sidecar:beta -->
+<!-- OBS-AddTag: caasp/v4.5/k8s-sidecar:%%PKG_VERSION%%-rev<VERSION> caasp/v4.5/k8s-sidecar:%%PKG_VERSION%%-rev<VERSION>-build<RELEASE> caasp/v4.5/k8s-sidecar:beta -->
 
 <image schemaversion="6.9" name="caasp-k8s-sidecar-image" xmlns:suse_label_helper="com.suse.label_helper">
   <description type="system">
@@ -13,7 +13,7 @@
       image="docker"
       derived_from="obsrepositories:/suse/sle15#15.2">
       <containerconfig
-        name="caasp/v5/k8s-sidecar"
+        name="caasp/v4.5/k8s-sidecar"
         tag="%%PKG_VERSION%%"
         maintainer="SUSE Containers Team &lt;containers@suse.com&gt;"
         user="nobody"
@@ -24,7 +24,7 @@
         </entrypoint>
         <subcommand clear="true"/>
         <labels>
-          <suse_label_helper:add_prefix prefix="com.suse.caasp.v5">
+          <suse_label_helper:add_prefix prefix="com.suse.caasp.v4.5">
             <label name="org.opencontainers.image.description" value="k8s-sidecar running on a SLES15 SP2 container guest"/>
             <label name="org.opencontainers.image.title" value="CaaSP k8s-sidecar container"/>
             <label name="org.opencontainers.image.created" value="%BUILDTIME%"/>
@@ -32,7 +32,7 @@
             <label name="org.opencontainers.image.url" value="https://www.suse.com/products/caas-platform/"/>
             <label name="org.opencontainers.image.version" value="%%PKG_VERSION%%"/>
             <label name="org.openbuildservice.disturl" value="%DISTURL%"/>
-            <label name="com.suse.reference" value="registry.suse.com/caasp/v5/k8s-sidecar:%%PKG_VERSION%%"/>
+            <label name="com.suse.reference" value="registry.suse.com/caasp/v4.5/k8s-sidecar:%%PKG_VERSION%%"/>
           </suse_label_helper:add_prefix>
         </labels>
       </containerconfig>

--- a/caasp-kube-apiserver-image/caasp-kube-apiserver-image.kiwi
+++ b/caasp-kube-apiserver-image/caasp-kube-apiserver-image.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<!-- OBS-AddTag: caasp/v5/kube-apiserver:v%%PKG_VERSION%%-rev<VERSION> caasp/v5/kube-apiserver:v%%PKG_VERSION%%-rev<VERSION>-build<RELEASE> caasp/v5/kube-apiserver:beta -->
+<!-- OBS-AddTag: caasp/v4.5/kube-apiserver:v%%PKG_VERSION%%-rev<VERSION> caasp/v4.5/kube-apiserver:v%%PKG_VERSION%%-rev<VERSION>-build<RELEASE> caasp/v4.5/kube-apiserver:beta -->
 
 <image schemaversion="6.9" name="caasp-kube-apiserver-image" xmlns:suse_label_helper="com.suse.label_helper">
   <description type="system">
@@ -13,13 +13,13 @@
       image="docker"
       derived_from="obsrepositories:/suse/sle15#15.2">
       <containerconfig
-        name="caasp/v5/kube-apiserver"
+        name="caasp/v4.5/kube-apiserver"
         tag="v%%PKG_VERSION%%"
         maintainer="SUSE Containers Team &lt;containers@suse.com&gt;">
         <entrypoint execute="kube-apiserver"/>
         <subcommand clear="true"/>
         <labels>
-          <suse_label_helper:add_prefix prefix="com.suse.caasp.v5">
+          <suse_label_helper:add_prefix prefix="com.suse.caasp.v4.5">
             <label name="org.opencontainers.image.description" value="CaaSP kube-apiserver running on a SLES15 SP2 container guest"/>
             <label name="org.opencontainers.image.title" value="CaaSP kube-apiserver container"/>
             <label name="org.opencontainers.image.created" value="%BUILDTIME%"/>
@@ -27,7 +27,7 @@
             <label name="org.opencontainers.image.url" value="https://www.suse.com/products/caas-platform/"/>
             <label name="org.opencontainers.image.version" value="%%PKG_VERSION%%"/>
             <label name="org.openbuildservice.disturl" value="%DISTURL%"/>
-            <label name="com.suse.reference" value="registry.suse.com/caasp/v5/kube-apiserver:v%%PKG_VERSION%%"/>
+            <label name="com.suse.reference" value="registry.suse.com/caasp/v4.5/kube-apiserver:v%%PKG_VERSION%%"/>
           </suse_label_helper:add_prefix>
         </labels>
       </containerconfig>

--- a/caasp-kube-controller-manager-image/caasp-kube-controller-manager-image.kiwi
+++ b/caasp-kube-controller-manager-image/caasp-kube-controller-manager-image.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<!-- OBS-AddTag: caasp/v5/kube-controller-manager:v%%PKG_VERSION%%-rev<VERSION> caasp/v5/kube-controller-manager:v%%PKG_VERSION%%-rev<VERSION>-build<RELEASE> caasp/v5/kube-controller-manager:beta -->
+<!-- OBS-AddTag: caasp/v4.5/kube-controller-manager:v%%PKG_VERSION%%-rev<VERSION> caasp/v4.5/kube-controller-manager:v%%PKG_VERSION%%-rev<VERSION>-build<RELEASE> caasp/v4.5/kube-controller-manager:beta -->
 
 <image schemaversion="6.9" name="caasp-kube-controller-manager-image" xmlns:suse_label_helper="com.suse.label_helper">
   <description type="system">
@@ -13,13 +13,13 @@
       image="docker"
       derived_from="obsrepositories:/suse/sle15#15.2">
       <containerconfig
-        name="caasp/v5/kube-controller-manager"
+        name="caasp/v4.5/kube-controller-manager"
         tag="v%%PKG_VERSION%%"
         maintainer="SUSE Containers Team &lt;containers@suse.com&gt;">
         <entrypoint execute="kube-controller-manager"/>
         <subcommand clear="true"/>
         <labels>
-          <suse_label_helper:add_prefix prefix="com.suse.caasp.v5">
+          <suse_label_helper:add_prefix prefix="com.suse.caasp.v4.5">
             <label name="org.opencontainers.image.description" value="CaaSP kube-controller-manager running on a SLES15 SP2 container guest"/>
             <label name="org.opencontainers.image.title" value="CaaSP kube-controller-manager container"/>
             <label name="org.opencontainers.image.created" value="%BUILDTIME%"/>
@@ -27,7 +27,7 @@
             <label name="org.opencontainers.image.url" value="https://www.suse.com/products/caas-platform/"/>
             <label name="org.opencontainers.image.version" value="%%PKG_VERSION%%"/>
             <label name="org.openbuildservice.disturl" value="%DISTURL%"/>
-            <label name="com.suse.reference" value="registry.suse.com/caasp/v5/kube-controller-manager:v%%PKG_VERSION%%"/>
+            <label name="com.suse.reference" value="registry.suse.com/caasp/v4.5/kube-controller-manager:v%%PKG_VERSION%%"/>
           </suse_label_helper:add_prefix>
         </labels>
       </containerconfig>

--- a/caasp-kube-proxy-image/caasp-kube-proxy-image.kiwi
+++ b/caasp-kube-proxy-image/caasp-kube-proxy-image.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<!-- OBS-AddTag: caasp/v5/kube-proxy:v%%PKG_VERSION%%-rev<VERSION> caasp/v5/kube-proxy:v%%PKG_VERSION%%-rev<VERSION>-build<RELEASE> caasp/v5/kube-proxy:beta -->
+<!-- OBS-AddTag: caasp/v4.5/kube-proxy:v%%PKG_VERSION%%-rev<VERSION> caasp/v4.5/kube-proxy:v%%PKG_VERSION%%-rev<VERSION>-build<RELEASE> caasp/v4.5/kube-proxy:beta -->
 
 <image schemaversion="6.9" name="caasp-kube-proxy-image" xmlns:suse_label_helper="com.suse.label_helper">
   <description type="system">
@@ -13,13 +13,13 @@
       image="docker"
       derived_from="obsrepositories:/suse/sle15#15.2">
       <containerconfig
-        name="caasp/v5/kube-proxy"
+        name="caasp/v4.5/kube-proxy"
         tag="v%%PKG_VERSION%%"
         maintainer="SUSE Containers Team &lt;containers@suse.com&gt;">
         <entrypoint execute="kube-proxy"/>
         <subcommand clear="true"/>
         <labels>
-          <suse_label_helper:add_prefix prefix="com.suse.caasp.v5">
+          <suse_label_helper:add_prefix prefix="com.suse.caasp.v4.5">
             <label name="org.opencontainers.image.description" value="CaaSP kube-proxy running on a SLES15 SP2 container guest"/>
             <label name="org.opencontainers.image.title" value="CaaSP kube-proxy container"/>
             <label name="org.opencontainers.image.created" value="%BUILDTIME%"/>
@@ -27,7 +27,7 @@
             <label name="org.opencontainers.image.url" value="https://www.suse.com/products/caas-platform/"/>
             <label name="org.opencontainers.image.version" value="%%PKG_VERSION%%"/>
             <label name="org.openbuildservice.disturl" value="%DISTURL%"/>
-            <label name="com.suse.reference" value="registry.suse.com/caasp/v5/kube-proxy:v%%PKG_VERSION%%"/>
+            <label name="com.suse.reference" value="registry.suse.com/caasp/v4.5/kube-proxy:v%%PKG_VERSION%%"/>
           </suse_label_helper:add_prefix>
         </labels>
       </containerconfig>

--- a/caasp-kube-scheduler-image/caasp-kube-scheduler-image.kiwi
+++ b/caasp-kube-scheduler-image/caasp-kube-scheduler-image.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<!-- OBS-AddTag: caasp/v5/kube-scheduler:v%%PKG_VERSION%%-rev<VERSION> caasp/v5/kube-scheduler:v%%PKG_VERSION%%-rev<VERSION>-build<RELEASE> caasp/v5/kube-scheduler:beta -->
+<!-- OBS-AddTag: caasp/v4.5/kube-scheduler:v%%PKG_VERSION%%-rev<VERSION> caasp/v4.5/kube-scheduler:v%%PKG_VERSION%%-rev<VERSION>-build<RELEASE> caasp/v4.5/kube-scheduler:beta -->
 
 <image schemaversion="6.9" name="caasp-kube-scheduler-image" xmlns:suse_label_helper="com.suse.label_helper">
   <description type="system">
@@ -13,13 +13,13 @@
       image="docker"
       derived_from="obsrepositories:/suse/sle15#15.2">
       <containerconfig
-        name="caasp/v5/kube-scheduler"
+        name="caasp/v4.5/kube-scheduler"
         tag="v%%PKG_VERSION%%"
         maintainer="SUSE Containers Team &lt;containers@suse.com&gt;">
         <entrypoint execute="kube-scheduler"/>
         <subcommand clear="true"/>
         <labels>
-          <suse_label_helper:add_prefix prefix="com.suse.caasp.v5">
+          <suse_label_helper:add_prefix prefix="com.suse.caasp.v4.5">
             <label name="org.opencontainers.image.description" value="CaaSP kube-scheduler running on a SLES15 SP2 container guest"/>
             <label name="org.opencontainers.image.title" value="CaaSP kube-scheduler container"/>
             <label name="org.opencontainers.image.created" value="%BUILDTIME%"/>
@@ -27,7 +27,7 @@
             <label name="org.opencontainers.image.url" value="https://www.suse.com/products/caas-platform/"/>
             <label name="org.opencontainers.image.version" value="%%PKG_VERSION%%"/>
             <label name="org.openbuildservice.disturl" value="%DISTURL%"/>
-            <label name="com.suse.reference" value="registry.suse.com/caasp/v5/kube-scheduler:v%%PKG_VERSION%%"/>
+            <label name="com.suse.reference" value="registry.suse.com/caasp/v4.5/kube-scheduler:v%%PKG_VERSION%%"/>
           </suse_label_helper:add_prefix>
         </labels>
       </containerconfig>

--- a/caasp-kube-state-metrics-image/caasp-kube-state-metrics-image.kiwi
+++ b/caasp-kube-state-metrics-image/caasp-kube-state-metrics-image.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<!-- OBS-AddTag: caasp/v5/kube-state-metrics:%%PKG_VERSION%%-rev<VERSION> caasp/v5/kube-state-metrics:%%PKG_VERSION%%-rev<VERSION>-build<RELEASE> caasp/v5/kube-state-metrics:beta -->
+<!-- OBS-AddTag: caasp/v4.5/kube-state-metrics:%%PKG_VERSION%%-rev<VERSION> caasp/v4.5/kube-state-metrics:%%PKG_VERSION%%-rev<VERSION>-build<RELEASE> caasp/v4.5/kube-state-metrics:beta -->
 
 <image schemaversion="6.9" name="caasp-kube-state-metrics-image" xmlns:suse_label_helper="com.suse.label_helper">
   <description type="system">
@@ -13,7 +13,7 @@
       image="docker"
       derived_from="obsrepositories:/suse/sle15#15.2">
       <containerconfig
-        name="caasp/v5/kube-state-metrics"
+        name="caasp/v4.5/kube-state-metrics"
         tag="%%PKG_VERSION%%"
         maintainer="SUSE Containers Team &lt;containers@suse.com&gt;">
         <expose>
@@ -26,7 +26,7 @@
         </entrypoint>
         <subcommand clear="true"/>
         <labels>
-          <suse_label_helper:add_prefix prefix="com.suse.caasp.v5">
+          <suse_label_helper:add_prefix prefix="com.suse.caasp.v4.5">
             <label name="org.opencontainers.image.description" value="Kube-state-metrics running on a SLES15 SP2 container guest"/>
             <label name="org.opencontainers.image.title" value="CaaSP Kube-state-metrics container"/>
             <label name="org.opencontainers.image.created" value="%BUILDTIME%"/>
@@ -34,7 +34,7 @@
             <label name="org.opencontainers.image.url" value="https://www.suse.com/products/caas-platform/"/>
             <label name="org.opencontainers.image.version" value="%%PKG_VERSION%%"/>
             <label name="org.openbuildservice.disturl" value="%DISTURL%"/>
-            <label name="com.suse.reference" value="registry.suse.com/caasp/v5/kube-state-metrics:%%PKG_VERSION%%"/>
+            <label name="com.suse.reference" value="registry.suse.com/caasp/v4.5/kube-state-metrics:%%PKG_VERSION%%"/>
           </suse_label_helper:add_prefix>
         </labels>
       </containerconfig>

--- a/caasp-kubernetes-client-image/caasp-kubernetes-client-image.kiwi
+++ b/caasp-kubernetes-client-image/caasp-kubernetes-client-image.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<!-- OBS-AddTag: caasp/v5/kubernetes-client:%%PKG_VERSION%%-rev<VERSION> caasp/v5/kubernetes-client:%%PKG_VERSION%%-rev<VERSION>-build<RELEASE> caasp/v5/kubernetes-client:beta -->
+<!-- OBS-AddTag: caasp/v4.5/kubernetes-client:%%PKG_VERSION%%-rev<VERSION> caasp/v4.5/kubernetes-client:%%PKG_VERSION%%-rev<VERSION>-build<RELEASE> caasp/v4.5/kubernetes-client:beta -->
 
 <image schemaversion="6.9" name="caasp-kubernetes-client-image" xmlns:suse_label_helper="com.suse.label_helper">
   <description type="system">
@@ -13,13 +13,13 @@
       image="docker"
       derived_from="obsrepositories:/suse/sle15#15.2">
       <containerconfig
-        name="caasp/v5/kubernetes-client"
+        name="caasp/v4.5/kubernetes-client"
         tag="%%PKG_VERSION%%"
         maintainer="SUSE Containers Team &lt;containers@suse.com&gt;">
         <entrypoint execute="kubectl"/>
         <subcommand clear="true"/>
         <labels>
-          <suse_label_helper:add_prefix prefix="com.suse.caasp.v5">
+          <suse_label_helper:add_prefix prefix="com.suse.caasp.v4.5">
             <label name="org.opencontainers.image.description" value="kubernetes-client running on a SLES15 SP2 container guest"/>
             <label name="org.opencontainers.image.title" value="CaaSP kubernetes-client container"/>
             <label name="org.opencontainers.image.created" value="%BUILDTIME%"/>
@@ -27,7 +27,7 @@
             <label name="org.opencontainers.image.url" value="https://www.suse.com/products/caas-platform/"/>
             <label name="org.opencontainers.image.version" value="%%PKG_VERSION%%"/>
             <label name="org.openbuildservice.disturl" value="%DISTURL%"/>
-            <label name="com.suse.reference" value="registry.suse.com/caasp/v5/kubernetes-client:%%PKG_VERSION%%"/>
+            <label name="com.suse.reference" value="registry.suse.com/caasp/v4.5/kubernetes-client:%%PKG_VERSION%%"/>
           </suse_label_helper:add_prefix>
         </labels>
       </containerconfig>

--- a/caasp-kucero-image/caasp-kucero-image.kiwi
+++ b/caasp-kucero-image/caasp-kucero-image.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<!-- OBS-AddTag: caasp/v5/kucero:%%PKG_VERSION%%-rev<VERSION> caasp/v5/kucero:%%PKG_VERSION%%-rev<VERSION>-build<RELEASE> caasp/v5/kucero:beta -->
+<!-- OBS-AddTag: caasp/v4.5/kucero:%%PKG_VERSION%%-rev<VERSION> caasp/v4.5/kucero:%%PKG_VERSION%%-rev<VERSION>-build<RELEASE> caasp/v4.5/kucero:beta -->
 
 <image schemaversion="6.9" name="caasp-kucero-image" xmlns:suse_label_helper="com.suse.label_helper">
   <description type="system">
@@ -13,13 +13,13 @@
       image="docker"
       derived_from="obsrepositories:/suse/sle15#15.2">
       <containerconfig
-        name="caasp/v5/kucero"
+        name="caasp/v4.5/kucero"
         tag="%%PKG_VERSION%%"
         maintainer="SUSE Containers Team &lt;containers@suse.com&gt;">
         <entrypoint execute="/usr/bin/kucero"/>
         <subcommand clear="true"/>
         <labels>
-          <suse_label_helper:add_prefix prefix="com.suse.caasp.v5">
+          <suse_label_helper:add_prefix prefix="com.suse.caasp.v4.5">
             <label name="org.opencontainers.image.description" value="kucero running on a SLES15 SP2 container guest"/>
             <label name="org.opencontainers.image.title" value="CaaSP kucero container"/>
             <label name="org.opencontainers.image.created" value="%BUILDTIME%"/>
@@ -27,7 +27,7 @@
             <label name="org.opencontainers.image.url" value="https://www.suse.com/products/caas-platform/"/>
             <label name="org.opencontainers.image.version" value="%%PKG_VERSION%%"/>
             <label name="org.openbuildservice.disturl" value="%DISTURL%"/>
-            <label name="com.suse.reference" value="registry.suse.com/caasp/v5/kucero:%%PKG_VERSION%%"/>
+            <label name="com.suse.reference" value="registry.suse.com/caasp/v4.5/kucero:%%PKG_VERSION%%"/>
           </suse_label_helper:add_prefix>
         </labels>
       </containerconfig>

--- a/caasp-kured-image/caasp-kured-image.kiwi
+++ b/caasp-kured-image/caasp-kured-image.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<!-- OBS-AddTag: caasp/v5/kured:%%PKG_VERSION%%-rev<VERSION> caasp/v5/kured:%%PKG_VERSION%%-rev<VERSION>-build<RELEASE> caasp/v5/kured:beta -->
+<!-- OBS-AddTag: caasp/v4.5/kured:%%PKG_VERSION%%-rev<VERSION> caasp/v4.5/kured:%%PKG_VERSION%%-rev<VERSION>-build<RELEASE> caasp/v4.5/kured:beta -->
 
 <image schemaversion="6.9" name="caasp-kured-image" xmlns:suse_label_helper="com.suse.label_helper">
   <description type="system">
@@ -13,13 +13,13 @@
       image="docker"
       derived_from="obsrepositories:/suse/sle15#15.2">
       <containerconfig
-        name="caasp/v5/kured"
+        name="caasp/v4.5/kured"
         tag="%%PKG_VERSION%%"
         maintainer="SUSE Containers Team &lt;containers@suse.com&gt;">
         <entrypoint execute="/usr/bin/kured"/>
         <subcommand clear="true"/>
         <labels>
-          <suse_label_helper:add_prefix prefix="com.suse.caasp.v5">
+          <suse_label_helper:add_prefix prefix="com.suse.caasp.v4.5">
             <label name="org.opencontainers.image.description" value="Image containing Kubernetes Reboot Daemon for CaaSP"/>
             <label name="org.opencontainers.image.title" value="CaaSP kured container"/>
             <label name="org.opencontainers.image.created" value="%BUILDTIME%"/>
@@ -27,7 +27,7 @@
             <label name="org.opencontainers.image.url" value="https://www.suse.com/products/caas-platform/"/>
             <label name="org.opencontainers.image.version" value="%%PKG_VERSION%%"/>
             <label name="org.openbuildservice.disturl" value="%DISTURL%"/>
-            <label name="com.suse.reference" value="registry.suse.com/caasp/v5/kured:%%PKG_VERSION%%"/>
+            <label name="com.suse.reference" value="registry.suse.com/caasp/v4.5/kured:%%PKG_VERSION%%"/>
           </suse_label_helper:add_prefix>
         </labels>
       </containerconfig>

--- a/caasp-metrics-server-image/caasp-metrics-server-image.kiwi
+++ b/caasp-metrics-server-image/caasp-metrics-server-image.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<!-- OBS-AddTag: caasp/v5/metrics-server:%%PKG_VERSION%%-rev<VERSION> caasp/v5/metrics-server:%%PKG_VERSION%%-rev<VERSION>-build<RELEASE> caasp/v5/metrics-server:beta -->
+<!-- OBS-AddTag: caasp/v4.5/metrics-server:%%PKG_VERSION%%-rev<VERSION> caasp/v4.5/metrics-server:%%PKG_VERSION%%-rev<VERSION>-build<RELEASE> caasp/v4.5/metrics-server:beta -->
 
 <image schemaversion="6.9" name="caasp-metrics-server-image" xmlns:suse_label_helper="com.suse.label_helper">
   <description type="system">
@@ -13,14 +13,14 @@
       image="docker"
       derived_from="obsrepositories:/suse/sle15#15.2">
       <containerconfig
-        name="caasp/v5/metrics-server"
+        name="caasp/v4.5/metrics-server"
         tag="%%PKG_VERSION%%"
         maintainer="SUSE Containers Team &lt;containers@suse.com&gt;"
         user="nobody">
         <entrypoint execute="metrics-server"/>
         <subcommand clear="true"/>
         <labels>
-          <suse_label_helper:add_prefix prefix="com.suse.caasp.v5">
+          <suse_label_helper:add_prefix prefix="com.suse.caasp.v4.5">
             <label name="org.opencontainers.image.description" value="metrics-server running on a SLES15 SP2 container guest"/>
             <label name="org.opencontainers.image.title" value="CaaSP metrics-server container"/>
             <label name="org.opencontainers.image.created" value="%BUILDTIME%"/>
@@ -28,7 +28,7 @@
             <label name="org.opencontainers.image.url" value="https://www.suse.com/products/caas-platform/"/>
             <label name="org.opencontainers.image.version" value="%%PKG_VERSION%%"/>
             <label name="org.openbuildservice.disturl" value="%DISTURL%"/>
-            <label name="com.suse.reference" value="registry.suse.com/caasp/v5/metrics-server:%%PKG_VERSION%%"/>
+            <label name="com.suse.reference" value="registry.suse.com/caasp/v4.5/metrics-server:%%PKG_VERSION%%"/>
           </suse_label_helper:add_prefix>
         </labels>
       </containerconfig>

--- a/caasp-multus-image/caasp-multus-image.kiwi
+++ b/caasp-multus-image/caasp-multus-image.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<!-- OBS-AddTag: caasp/v5/multus:%%PKG_VERSION%%-rev<VERSION> caasp/v5/multus:%%PKG_VERSION%%-rev<VERSION>-build<RELEASE> -->
+<!-- OBS-AddTag: caasp/v4.5/multus:%%PKG_VERSION%%-rev<VERSION> caasp/v4.5/multus:%%PKG_VERSION%%-rev<VERSION>-build<RELEASE> -->
 
 <image schemaversion="6.9" name="caasp-multus-image" xmlns:suse_label_helper="com.suse.label_helper">
   <description type="system">
@@ -13,7 +13,7 @@
       image="docker"
       derived_from="obsrepositories:/suse/sle15#15.2">
       <containerconfig
-        name="caasp/v5/multus"
+        name="caasp/v4.5/multus"
         tag="%%PKG_VERSION%%"
         maintainer="SUSE Containers Team &lt;containers@suse.com&gt;">
         <entrypoint execute="/usr/bin/multus"/>
@@ -27,7 +27,7 @@
             <label name="org.opencontainers.image.url" value="https://www.suse.com/products/caas-platform/"/>
             <label name="org.opencontainers.image.version" value="%%PKG_VERSION%%"/>
             <label name="org.openbuildservice.disturl" value="%DISTURL%"/>
-            <label name="com.suse.reference" value="registry.suse.com/caasp/v5/multus:%%PKG_VERSION%%"/>
+            <label name="com.suse.reference" value="registry.suse.com/caasp/v4.5/multus:%%PKG_VERSION%%"/>
           </suse_label_helper:add_prefix>
         </labels>
       </containerconfig>

--- a/caasp-pause-image/caasp-pause-image.kiwi
+++ b/caasp-pause-image/caasp-pause-image.kiwi
@@ -5,7 +5,7 @@
     requirements.
 -->
 
-<!-- OBS-AddTag: caasp/v5/pause:3.2-rev<VERSION> caasp/v5/pause:3.2-rev<VERSION>-build<RELEASE> caasp/v5/pause:beta -->
+<!-- OBS-AddTag: caasp/v4.5/pause:3.2-rev<VERSION> caasp/v4.5/pause:3.2-rev<VERSION>-build<RELEASE> caasp/v4.5/pause:beta -->
 
 <image schemaversion="6.9" name="caasp-pause-image" xmlns:suse_label_helper="com.suse.label_helper">
   <description type="system">
@@ -16,12 +16,12 @@
   <preferences>
     <type image="docker">
       <containerconfig
-        name="caasp/v5/pause"
+        name="caasp/v4.5/pause"
         tag="3.2"
         maintainer="SUSE Containers Team &lt;containers@suse.com&gt;">
         <entrypoint execute="/usr/bin/caasp-pause"/>
         <labels>
-          <suse_label_helper:add_prefix prefix="com.suse.caasp.v5">
+          <suse_label_helper:add_prefix prefix="com.suse.caasp.v4.5">
             <label name="org.opencontainers.image.description" value="caasp-pause running on a SLES15 SP2 container guest"/>
             <label name="org.opencontainers.image.title" value="CaaSP pause container"/>
             <label name="org.opencontainers.image.created" value="%BUILDTIME%"/>
@@ -29,7 +29,7 @@
             <label name="org.opencontainers.image.url" value="https://www.suse.com/products/caas-platform/"/>
             <label name="org.opencontainers.image.version" value="3.2"/>
             <label name="org.openbuildservice.disturl" value="%DISTURL%"/>
-            <label name="com.suse.reference" value="registry.suse.com/caasp/v5/pause:3.2"/>
+            <label name="com.suse.reference" value="registry.suse.com/caasp/v4.5/pause:3.2"/>
           </suse_label_helper:add_prefix>
         </labels>
       </containerconfig>

--- a/caasp-prometheus-alertmanager-image/caasp-prometheus-alertmanager-image.kiwi
+++ b/caasp-prometheus-alertmanager-image/caasp-prometheus-alertmanager-image.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<!-- OBS-AddTag: caasp/v5/prometheus-alertmanager:%%PKG_VERSION%%-rev<VERSION> caasp/v5/prometheus-alertmanager:%%PKG_VERSION%%-rev<VERSION>-build<RELEASE> caasp/v5/prometheus-alertmanager:beta -->
+<!-- OBS-AddTag: caasp/v4.5/prometheus-alertmanager:%%PKG_VERSION%%-rev<VERSION> caasp/v4.5/prometheus-alertmanager:%%PKG_VERSION%%-rev<VERSION>-build<RELEASE> caasp/v4.5/prometheus-alertmanager:beta -->
 
 <image schemaversion="6.9" name="caasp-prometheus-alertmanager-image" xmlns:suse_label_helper="com.suse.label_helper">
   <description type="system">
@@ -13,7 +13,7 @@
       image="docker"
       derived_from="obsrepositories:/suse/sle15#15.2">
       <containerconfig
-        name="caasp/v5/prometheus-alertmanager"
+        name="caasp/v4.5/prometheus-alertmanager"
         tag="%%PKG_VERSION%%"
         maintainer="SUSE Containers Team &lt;containers@suse.com&gt;">
         <expose>
@@ -22,7 +22,7 @@
         <entrypoint execute="/usr/bin/prometheus-alertmanager"/>
         <subcommand clear="true"/>
         <labels>
-          <suse_label_helper:add_prefix prefix="com.suse.caasp.v5">
+          <suse_label_helper:add_prefix prefix="com.suse.caasp.v4.5">
             <label name="org.opencontainers.image.description" value="Prometheus alertmanager running on a SLES15 SP2 container guest"/>
             <label name="org.opencontainers.image.title" value="CaaSP Prometheus alertmanager container"/>
             <label name="org.opencontainers.image.created" value="%BUILDTIME%"/>
@@ -30,7 +30,7 @@
             <label name="org.opencontainers.image.url" value="https://www.suse.com/products/caas-platform/"/>
             <label name="org.opencontainers.image.version" value="%%PKG_VERSION%%"/>
             <label name="org.openbuildservice.disturl" value="%DISTURL%"/>
-            <label name="com.suse.reference" value="registry.suse.com/caasp/v5/prometheus-alertmanager:%%PKG_VERSION%%"/>
+            <label name="com.suse.reference" value="registry.suse.com/caasp/v4.5/prometheus-alertmanager:%%PKG_VERSION%%"/>
           </suse_label_helper:add_prefix>
         </labels>
       </containerconfig>

--- a/caasp-prometheus-node-exporter-image/caasp-prometheus-node-exporter-image.kiwi
+++ b/caasp-prometheus-node-exporter-image/caasp-prometheus-node-exporter-image.kiwi
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 
-<!-- OBS-AddTag: caasp/v5/prometheus-node-exporter:%%PKG_VERSION%%-rev<VERSION> caasp/v5/prometheus-node-exporter:%%PKG_VERSION%%-rev<VERSION>-build<RELEASE> caasp/v5/prometheus-node-exporter:beta -->
+<!-- OBS-AddTag: caasp/v4.5/prometheus-node-exporter:%%PKG_VERSION%%-rev<VERSION> caasp/v4.5/prometheus-node-exporter:%%PKG_VERSION%%-rev<VERSION>-build<RELEASE> caasp/v4.5/prometheus-node-exporter:beta -->
  
 
 <image schemaversion="6.9" name="caasp-prometheus-node-exporter-image" xmlns:suse_label_helper="com.suse.label_helper">
@@ -15,7 +15,7 @@
       image="docker"
       derived_from="obsrepositories:/suse/sle15#15.2">
       <containerconfig
-        name="caasp/v5/prometheus-node-exporter"
+        name="caasp/v4.5/prometheus-node-exporter"
         tag="%%PKG_VERSION%%"
         maintainer="SUSE Containers Team &lt;containers@suse.com&gt;">
         <expose>
@@ -24,7 +24,7 @@
         <entrypoint execute="/usr/bin/node_exporter"/>
         <subcommand clear="true"/>
         <labels>
-          <suse_label_helper:add_prefix prefix="com.suse.caasp.v5">
+          <suse_label_helper:add_prefix prefix="com.suse.caasp.v4.5">
             <label name="org.opencontainers.image.description" value="Prometheus node-exporter running on a SLES15 SP2 container guest"/>
             <label name="org.opencontainers.image.title" value="CaaSP Prometheus node-exporter container"/>
             <label name="org.opencontainers.image.created" value="%BUILDTIME%"/>
@@ -32,7 +32,7 @@
             <label name="org.opencontainers.image.url" value="https://www.suse.com/products/caas-platform/"/>
             <label name="org.opencontainers.image.version" value="%%PKG_VERSION%%"/>
             <label name="org.openbuildservice.disturl" value="%DISTURL%"/>
-            <label name="com.suse.reference" value="registry.suse.com/caasp/v5/prometheus-node-exporter:%%PKG_VERSION%%"/>
+            <label name="com.suse.reference" value="registry.suse.com/caasp/v4.5/prometheus-node-exporter:%%PKG_VERSION%%"/>
           </suse_label_helper:add_prefix>
         </labels>
       </containerconfig>

--- a/caasp-prometheus-pushgateway-image/caasp-prometheus-pushgateway-image.kiwi
+++ b/caasp-prometheus-pushgateway-image/caasp-prometheus-pushgateway-image.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<!-- OBS-AddTag: caasp/v5/prometheus-pushgateway:%%PKG_VERSION%%-rev<VERSION> caasp/v5/prometheus-pushgateway:%%PKG_VERSION%%-rev<VERSION>-build<RELEASE> caasp/v5/prometheus-pushgateway:beta -->
+<!-- OBS-AddTag: caasp/v4.5/prometheus-pushgateway:%%PKG_VERSION%%-rev<VERSION> caasp/v4.5/prometheus-pushgateway:%%PKG_VERSION%%-rev<VERSION>-build<RELEASE> caasp/v4.5/prometheus-pushgateway:beta -->
 
 <image schemaversion="6.9" name="caasp-prometheus-pushgateway-image" xmlns:suse_label_helper="com.suse.label_helper">
   <description type="system">
@@ -13,7 +13,7 @@
       image="docker"
       derived_from="obsrepositories:/suse/sle15#15.2">
       <containerconfig
-        name="caasp/v5/prometheus-pushgateway"
+        name="caasp/v4.5/prometheus-pushgateway"
         tag="%%PKG_VERSION%%"
         maintainer="SUSE Containers Team &lt;containers@suse.com&gt;">
         <expose>
@@ -22,7 +22,7 @@
         <entrypoint execute="/usr/bin/pushgateway"/>
         <subcommand clear="true"/>
         <labels>
-          <suse_label_helper:add_prefix prefix="com.suse.caasp.v5">
+          <suse_label_helper:add_prefix prefix="com.suse.caasp.v4.5">
             <label name="org.opencontainers.image.description" value="Prometheus alertmanager running on a SLES15 SP2 container guest"/>
             <label name="org.opencontainers.image.title" value="CaaSP Prometheus alertmanager container"/>
             <label name="org.opencontainers.image.created" value="%BUILDTIME%"/>
@@ -30,7 +30,7 @@
             <label name="org.opencontainers.image.url" value="https://www.suse.com/products/caas-platform/"/>
             <label name="org.opencontainers.image.version" value="%%PKG_VERSION%%"/>
             <label name="org.openbuildservice.disturl" value="%DISTURL%"/>
-            <label name="com.suse.reference" value="registry.suse.com/caasp/v5/prometheus-pushgateway:%%PKG_VERSION%%"/>
+            <label name="com.suse.reference" value="registry.suse.com/caasp/v4.5/prometheus-pushgateway:%%PKG_VERSION%%"/>
           </suse_label_helper:add_prefix>
         </labels>
       </containerconfig>

--- a/caasp-prometheus-server-image/caasp-prometheus-server-image.kiwi
+++ b/caasp-prometheus-server-image/caasp-prometheus-server-image.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<!-- OBS-AddTag: caasp/v5/prometheus-server:%%PKG_VERSION%%-rev<VERSION> caasp/v5/prometheus-server:%%PKG_VERSION%%-rev<VERSION>-build<RELEASE> caasp/v5/prometheus-server:beta -->
+<!-- OBS-AddTag: caasp/v4.5/prometheus-server:%%PKG_VERSION%%-rev<VERSION> caasp/v4.5/prometheus-server:%%PKG_VERSION%%-rev<VERSION>-build<RELEASE> caasp/v4.5/prometheus-server:beta -->
 
 <image schemaversion="6.9" name="caasp-prometheus-server-image" xmlns:suse_label_helper="com.suse.label_helper">
   <description type="system">
@@ -13,7 +13,7 @@
       image="docker"
       derived_from="obsrepositories:/suse/sle15#15.2">
       <containerconfig
-        name="caasp/v5/prometheus-server"
+        name="caasp/v4.5/prometheus-server"
         tag="%%PKG_VERSION%%"
         maintainer="SUSE Containers Team &lt;containers@suse.com&gt;">
         <expose>
@@ -22,7 +22,7 @@
         <entrypoint execute="/usr/bin/prometheus"/>
         <subcommand clear="true"/>
         <labels>
-          <suse_label_helper:add_prefix prefix="com.suse.caasp.v5">
+          <suse_label_helper:add_prefix prefix="com.suse.caasp.v4.5">
             <label name="org.opencontainers.image.description" value="Prometheus server running on a SLES15 SP2 container guest"/>
             <label name="org.opencontainers.image.title" value="CaaSP Prometheus server container"/>
             <label name="org.opencontainers.image.created" value="%BUILDTIME%"/>
@@ -30,7 +30,7 @@
             <label name="org.opencontainers.image.url" value="https://www.suse.com/products/caas-platform/"/>
             <label name="org.opencontainers.image.version" value="%%PKG_VERSION%%"/>
             <label name="org.openbuildservice.disturl" value="%DISTURL%"/>
-            <label name="com.suse.reference" value="registry.suse.com/caasp/v5/prometheus-server:%%PKG_VERSION%%"/>
+            <label name="com.suse.reference" value="registry.suse.com/caasp/v4.5/prometheus-server:%%PKG_VERSION%%"/>
           </suse_label_helper:add_prefix>
         </labels>
       </containerconfig>

--- a/caasp-reloader-image/caasp-reloader-image.kiwi
+++ b/caasp-reloader-image/caasp-reloader-image.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<!-- OBS-AddTag: caasp/v5/reloader:%%PKG_VERSION%%-rev<VERSION> caasp/v5/reloader:%%PKG_VERSION%%-rev<VERSION>-build<RELEASE> caasp/v5/reloader:beta -->
+<!-- OBS-AddTag: caasp/v4.5/reloader:%%PKG_VERSION%%-rev<VERSION> caasp/v4.5/reloader:%%PKG_VERSION%%-rev<VERSION>-build<RELEASE> caasp/v4.5/reloader:beta -->
 
 <image schemaversion="6.9" name="caasp-reloader-image" xmlns:suse_label_helper="com.suse.label_helper">
   <description type="system">
@@ -13,14 +13,14 @@
       image="docker"
       derived_from="obsrepositories:/suse/sle15#15.2">
       <containerconfig
-        name="caasp/v5/reloader"
+        name="caasp/v4.5/reloader"
         tag="%%PKG_VERSION%%"
         maintainer="SUSE Containers Team &lt;containers@suse.com&gt;"
         user="nobody">
         <entrypoint execute="/usr/bin/Reloader"/>
         <subcommand clear="true"/>
         <labels>
-          <suse_label_helper:add_prefix prefix="com.suse.caasp.v5">
+          <suse_label_helper:add_prefix prefix="com.suse.caasp.v4.5">
             <label name="org.opencontainers.image.description" value="reloader running on a SLES15 SP2 container guest"/>
             <label name="org.opencontainers.image.title" value="CaaSP reloader container"/>
             <label name="org.opencontainers.image.created" value="%BUILDTIME%"/>
@@ -28,7 +28,7 @@
             <label name="org.opencontainers.image.url" value="https://www.suse.com/products/caas-platform/"/>
             <label name="org.opencontainers.image.version" value="%%PKG_VERSION%%"/>
             <label name="org.openbuildservice.disturl" value="%DISTURL%"/>
-            <label name="com.suse.reference" value="registry.suse.com/caasp/v5/reloader:%%PKG_VERSION%%"/>
+            <label name="com.suse.reference" value="registry.suse.com/caasp/v4.5/reloader:%%PKG_VERSION%%"/>
           </suse_label_helper:add_prefix>
         </labels>
       </containerconfig>

--- a/caasp-rsyslog-image/caasp-rsyslog-image.kiwi
+++ b/caasp-rsyslog-image/caasp-rsyslog-image.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<!-- OBS-AddTag: caasp/v5/rsyslog:%%PKG_VERSION%%-rev<VERSION> caasp/v5/rsyslog:%%PKG_VERSION%%-rev<VERSION>-build<RELEASE> caasp/v5/rsyslog:beta -->
+<!-- OBS-AddTag: caasp/v4.5/rsyslog:%%PKG_VERSION%%-rev<VERSION> caasp/v4.5/rsyslog:%%PKG_VERSION%%-rev<VERSION>-build<RELEASE> caasp/v4.5/rsyslog:beta -->
 
 <image schemaversion="6.9" name="caasp-rsyslog-image" xmlns:suse_label_helper="com.suse.label_helper">
   <description type="system">
@@ -13,7 +13,7 @@
       image="docker"
       derived_from="obsrepositories:/suse/sle15#15.2">
       <containerconfig
-        name="caasp/v5/rsyslog"
+        name="caasp/v4.5/rsyslog"
         tag="%%PKG_VERSION%%"
         maintainer="SUSE Containers Team &lt;containers@suse.com&gt;">
         <entrypoint execute="/sbin/rsyslogd">
@@ -21,7 +21,7 @@
         </entrypoint>
         <subcommand clear="true"/>
         <labels>
-          <suse_label_helper:add_prefix prefix="com.suse.caasp.v5">
+          <suse_label_helper:add_prefix prefix="com.suse.caasp.v4.5">
             <label name="org.opencontainers.image.description" value="CaaSP rsyslog running on a SLES15 SP2 container guest"/>
             <label name="org.opencontainers.image.title" value="CaaSP rsyslog container"/>
             <label name="org.opencontainers.image.created" value="%BUILDTIME%"/>
@@ -29,7 +29,7 @@
             <label name="org.opencontainers.image.url" value="https://www.suse.com/products/caas-platform/"/>
             <label name="org.opencontainers.image.version" value="%%PKG_VERSION%%"/>
             <label name="org.openbuildservice.disturl" value="%DISTURL%"/>
-            <label name="com.suse.reference" value="registry.suse.com/caasp/v5/rsyslog:%%PKG_VERSION%%"/>
+            <label name="com.suse.reference" value="registry.suse.com/caasp/v4.5/rsyslog:%%PKG_VERSION%%"/>
           </suse_label_helper:add_prefix>
         </labels>
       </containerconfig>

--- a/caasp-skuba-tooling-image/caasp-skuba-tooling-image.kiwi
+++ b/caasp-skuba-tooling-image/caasp-skuba-tooling-image.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<!-- OBS-AddTag: caasp/v5/skuba-tooling:0.1.0-rev<VERSION> caasp/v5/skuba-tooling:0.1.0-rev<VERSION>-build<RELEASE> caasp/v5/skuba-tooling:beta -->
+<!-- OBS-AddTag: caasp/v4.5/skuba-tooling:0.1.0-rev<VERSION> caasp/v4.5/skuba-tooling:0.1.0-rev<VERSION>-build<RELEASE> caasp/v4.5/skuba-tooling:beta -->
 
 <image schemaversion="6.9" name="caasp-skuba-tooling-image" xmlns:suse_label_helper="com.suse.label_helper">
   <description type="system">
@@ -13,11 +13,11 @@
       image="docker"
       derived_from="obsrepositories:/suse/sle15#15.2">
       <containerconfig
-        name="caasp/v5/skuba-tooling"
+        name="caasp/v4.5/skuba-tooling"
         tag="0.1.0"
         maintainer="SUSE Containers Team &lt;containers@suse.com&gt;">
         <labels>
-          <suse_label_helper:add_prefix prefix="com.suse.caasp.v5">
+          <suse_label_helper:add_prefix prefix="com.suse.caasp.v4.5">
             <label name="org.opencontainers.image.description" value="CaaSP skuba-tooling running on a SLES15 SP2 container guest"/>
             <label name="org.opencontainers.image.title" value="CaaSP skuba-tooling container"/>
             <label name="org.opencontainers.image.created" value="%BUILDTIME%"/>
@@ -25,7 +25,7 @@
             <label name="org.opencontainers.image.url" value="https://www.suse.com/products/caas-platform/"/>
             <label name="org.opencontainers.image.version" value="%%PKG_VERSION%%"/>
             <label name="org.openbuildservice.disturl" value="%DISTURL%"/>
-            <label name="com.suse.reference" value="registry.suse.com/caasp/v5/skuba-tooling:0.1.0"/>
+            <label name="com.suse.reference" value="registry.suse.com/caasp/v4.5/skuba-tooling:0.1.0"/>
           </suse_label_helper:add_prefix>
         </labels>
       </containerconfig>

--- a/caasp-velero-image/caasp-velero-image.kiwi
+++ b/caasp-velero-image/caasp-velero-image.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<!-- OBS-AddTag: caasp/v5/velero:%%PKG_VERSION%%-rev<VERSION> caasp/v5/velero:%%PKG_VERSION%%-rev<VERSION>-build<RELEASE> caasp/v5/velero:beta -->
+<!-- OBS-AddTag: caasp/v4.5/velero:%%PKG_VERSION%%-rev<VERSION> caasp/v4.5/velero:%%PKG_VERSION%%-rev<VERSION>-build<RELEASE> caasp/v4.5/velero:beta -->
 
 <image schemaversion="6.9" name="caasp-velero-image" xmlns:suse_label_helper="com.suse.label_helper">
   <description type="system">
@@ -13,14 +13,14 @@
       image="docker"
       derived_from="obsrepositories:/suse/sle15#15.2">
       <containerconfig
-        name="caasp/v5/velero"
+        name="caasp/v4.5/velero"
         tag="%%PKG_VERSION%%"
         maintainer="SUSE Containers Team &lt;containers@suse.com&gt;"
         user="nobody">
         <entrypoint execute="velero"/>
         <subcommand clear="true"/>
         <labels>
-          <suse_label_helper:add_prefix prefix="com.suse.caasp.v5">
+          <suse_label_helper:add_prefix prefix="com.suse.caasp.v4.5">
             <label name="org.opencontainers.image.description" value="velero running on a SLES15 SP2 container guest"/>
             <label name="org.opencontainers.image.title" value="CaaSP velero container"/>
             <label name="org.opencontainers.image.created" value="%BUILDTIME%"/>
@@ -28,7 +28,7 @@
             <label name="org.opencontainers.image.url" value="https://www.suse.com/products/caas-platform/"/>
             <label name="org.opencontainers.image.version" value="%%PKG_VERSION%%"/>
             <label name="org.openbuildservice.disturl" value="%DISTURL%"/>
-            <label name="com.suse.reference" value="registry.suse.com/caasp/v5/velero:%%PKG_VERSION%%"/>
+            <label name="com.suse.reference" value="registry.suse.com/caasp/v4.5/velero:%%PKG_VERSION%%"/>
           </suse_label_helper:add_prefix>
         </labels>
       </containerconfig>

--- a/caasp-velero-plugin-for-aws-image/caasp-velero-plugin-for-aws-image.kiwi
+++ b/caasp-velero-plugin-for-aws-image/caasp-velero-plugin-for-aws-image.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<!-- OBS-AddTag: caasp/v5/velero-plugin-for-aws:%%PKG_VERSION%%-rev<VERSION> caasp/v5/velero-plugin-for-aws:%%PKG_VERSION%%-rev<VERSION>-build<RELEASE> caasp/v5/velero-plugin-for-aws:beta -->
+<!-- OBS-AddTag: caasp/v4.5/velero-plugin-for-aws:%%PKG_VERSION%%-rev<VERSION> caasp/v4.5/velero-plugin-for-aws:%%PKG_VERSION%%-rev<VERSION>-build<RELEASE> caasp/v4.5/velero-plugin-for-aws:beta -->
 
 <image schemaversion="6.9" name="caasp-velero-plugin-for-aws-image" xmlns:suse_label_helper="com.suse.label_helper">
   <description type="system">
@@ -13,7 +13,7 @@
       image="docker"
       derived_from="obsrepositories:/suse/sle15#15.2">
       <containerconfig
-        name="caasp/v5/velero-plugin-for-aws"
+        name="caasp/v4.5/velero-plugin-for-aws"
         tag="%%PKG_VERSION%%"
         maintainer="SUSE Containers Team &lt;containers@suse.com&gt;"
         user="nobody">
@@ -23,7 +23,7 @@
         </entrypoint>
         <subcommand clear="true"/>
         <labels>
-          <suse_label_helper:add_prefix prefix="com.suse.caasp.v5">
+          <suse_label_helper:add_prefix prefix="com.suse.caasp.v4.5">
             <label name="org.opencontainers.image.description" value="velero-plugin-for-aws running on a SLES15 SP2 container guest"/>
             <label name="org.opencontainers.image.title" value="CaaSP velero-plugin-for-aws container"/>
             <label name="org.opencontainers.image.created" value="%BUILDTIME%"/>
@@ -31,7 +31,7 @@
             <label name="org.opencontainers.image.url" value="https://www.suse.com/products/caas-platform/"/>
             <label name="org.opencontainers.image.version" value="%%PKG_VERSION%%"/>
             <label name="org.openbuildservice.disturl" value="%DISTURL%"/>
-            <label name="com.suse.reference" value="registry.suse.com/caasp/v5/velero-plugin-for-aws:%%PKG_VERSION%%"/>
+            <label name="com.suse.reference" value="registry.suse.com/caasp/v4.5/velero-plugin-for-aws:%%PKG_VERSION%%"/>
           </suse_label_helper:add_prefix>
         </labels>
       </containerconfig>

--- a/caasp-velero-plugin-for-gcp-image/caasp-velero-plugin-for-gcp-image.kiwi
+++ b/caasp-velero-plugin-for-gcp-image/caasp-velero-plugin-for-gcp-image.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<!-- OBS-AddTag: caasp/v5/velero-plugin-for-gcp:%%PKG_VERSION%%-rev<VERSION> caasp/v5/velero-plugin-for-gcp:%%PKG_VERSION%%-rev<VERSION>-build<RELEASE> caasp/v5/velero-plugin-for-gcp:beta -->
+<!-- OBS-AddTag: caasp/v4.5/velero-plugin-for-gcp:%%PKG_VERSION%%-rev<VERSION> caasp/v4.5/velero-plugin-for-gcp:%%PKG_VERSION%%-rev<VERSION>-build<RELEASE> caasp/v4.5/velero-plugin-for-gcp:beta -->
 
 <image schemaversion="6.9" name="caasp-velero-plugin-for-gcp-image" xmlns:suse_label_helper="com.suse.label_helper">
   <description type="system">
@@ -13,7 +13,7 @@
       image="docker"
       derived_from="obsrepositories:/suse/sle15#15.2">
       <containerconfig
-        name="caasp/v5/velero-plugin-for-gcp"
+        name="caasp/v4.5/velero-plugin-for-gcp"
         tag="%%PKG_VERSION%%"
         maintainer="SUSE Containers Team &lt;containers@suse.com&gt;">
         <entrypoint execute="bash">
@@ -22,7 +22,7 @@
         </entrypoint>
         <subcommand clear="true"/>
         <labels>
-          <suse_label_helper:add_prefix prefix="com.suse.caasp.v5">
+          <suse_label_helper:add_prefix prefix="com.suse.caasp.v4.5">
             <label name="org.opencontainers.image.description" value="velero-plugin-for-gcp running on a SLES15 SP2 container guest"/>
             <label name="org.opencontainers.image.title" value="CaaSP velero-plugin-for-gcp container"/>
             <label name="org.opencontainers.image.created" value="%BUILDTIME%"/>
@@ -30,7 +30,7 @@
             <label name="org.opencontainers.image.url" value="https://www.suse.com/products/caas-platform/"/>
             <label name="org.opencontainers.image.version" value="%%PKG_VERSION%%"/>
             <label name="org.openbuildservice.disturl" value="%DISTURL%"/>
-            <label name="com.suse.reference" value="registry.suse.com/caasp/v5/velero-plugin-for-gcp:%%PKG_VERSION%%"/>
+            <label name="com.suse.reference" value="registry.suse.com/caasp/v4.5/velero-plugin-for-gcp:%%PKG_VERSION%%"/>
           </suse_label_helper:add_prefix>
         </labels>
       </containerconfig>

--- a/caasp-velero-plugin-for-microsoft-azure-image/caasp-velero-plugin-for-microsoft-azure-image.kiwi
+++ b/caasp-velero-plugin-for-microsoft-azure-image/caasp-velero-plugin-for-microsoft-azure-image.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<!-- OBS-AddTag: caasp/v5/velero-plugin-for-microsoft-azure:%%PKG_VERSION%%-rev<VERSION> caasp/v5/velero-plugin-for-microsoft-azure:%%PKG_VERSION%%-rev<VERSION>-build<RELEASE> caasp/v5/velero-plugin-for-microsoft-azure:beta -->
+<!-- OBS-AddTag: caasp/v4.5/velero-plugin-for-microsoft-azure:%%PKG_VERSION%%-rev<VERSION> caasp/v4.5/velero-plugin-for-microsoft-azure:%%PKG_VERSION%%-rev<VERSION>-build<RELEASE> caasp/v4.5/velero-plugin-for-microsoft-azure:beta -->
 
 <image schemaversion="6.9" name="caasp-velero-plugin-for-microsoft-azure-image" xmlns:suse_label_helper="com.suse.label_helper">
   <description type="system">
@@ -13,7 +13,7 @@
       image="docker"
       derived_from="obsrepositories:/suse/sle15#15.2">
       <containerconfig
-        name="caasp/v5/velero-plugin-for-microsoft-azure"
+        name="caasp/v4.5/velero-plugin-for-microsoft-azure"
         tag="%%PKG_VERSION%%"
         maintainer="SUSE Containers Team &lt;containers@suse.com&gt;"
         user="nobody">
@@ -23,7 +23,7 @@
         </entrypoint>
         <subcommand clear="true"/>
         <labels>
-          <suse_label_helper:add_prefix prefix="com.suse.caasp.v5">
+          <suse_label_helper:add_prefix prefix="com.suse.caasp.v4.5">
             <label name="org.opencontainers.image.description" value="velero-plugin-for-microsoft-azure running on a SLES15 SP2 container guest"/>
             <label name="org.opencontainers.image.title" value="CaaSP velero-plugin-for-microsoft-azure container"/>
             <label name="org.opencontainers.image.created" value="%BUILDTIME%"/>
@@ -31,7 +31,7 @@
             <label name="org.opencontainers.image.url" value="https://www.suse.com/products/caas-platform/"/>
             <label name="org.opencontainers.image.version" value="%%PKG_VERSION%%"/>
             <label name="org.openbuildservice.disturl" value="%DISTURL%"/>
-            <label name="com.suse.reference" value="registry.suse.com/caasp/v5/velero-plugin-for-microsoft-azure:%%PKG_VERSION%%"/>
+            <label name="com.suse.reference" value="registry.suse.com/caasp/v4.5/velero-plugin-for-microsoft-azure:%%PKG_VERSION%%"/>
           </suse_label_helper:add_prefix>
         </labels>
       </containerconfig>

--- a/caasp-velero-restic-restore-helper-image/caasp-velero-restic-restore-helper-image.kiwi
+++ b/caasp-velero-restic-restore-helper-image/caasp-velero-restic-restore-helper-image.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<!-- OBS-AddTag: caasp/v5/velero-restic-restore-helper:%%PKG_VERSION%%-rev<VERSION> caasp/v5/velero-restic-restore-helper:%%PKG_VERSION%%-rev<VERSION>-build<RELEASE> caasp/v5/velero-restic-restore-helper:beta -->
+<!-- OBS-AddTag: caasp/v4.5/velero-restic-restore-helper:%%PKG_VERSION%%-rev<VERSION> caasp/v4.5/velero-restic-restore-helper:%%PKG_VERSION%%-rev<VERSION>-build<RELEASE> caasp/v4.5/velero-restic-restore-helper:beta -->
 
 <image schemaversion="6.9" name="caasp-velero-restic-restore-helper-image" xmlns:suse_label_helper="com.suse.label_helper">
   <description type="system">
@@ -13,14 +13,14 @@
       image="docker"
       derived_from="obsrepositories:/suse/sle15#15.2">
       <containerconfig
-        name="caasp/v5/velero-restic-restore-helper"
+        name="caasp/v4.5/velero-restic-restore-helper"
         tag="%%PKG_VERSION%%"
         maintainer="SUSE Containers Team &lt;containers@suse.com&gt;"
         user="nobody">
         <entrypoint execute="velero-restic-restore-helper"/>
         <subcommand clear="true"/>
         <labels>
-          <suse_label_helper:add_prefix prefix="com.suse.caasp.v5">
+          <suse_label_helper:add_prefix prefix="com.suse.caasp.v4.5">
             <label name="org.opencontainers.image.description" value="velero-restic-restore-helper running on a SLES15 SP2 container guest"/>
             <label name="org.opencontainers.image.title" value="CaaSP velero-restic-restore-helper container"/>
             <label name="org.opencontainers.image.created" value="%BUILDTIME%"/>
@@ -28,7 +28,7 @@
             <label name="org.opencontainers.image.url" value="https://www.suse.com/products/caas-platform/"/>
             <label name="org.opencontainers.image.version" value="%%PKG_VERSION%%"/>
             <label name="org.openbuildservice.disturl" value="%DISTURL%"/>
-            <label name="com.suse.reference" value="registry.suse.com/caasp/v5/velero-restic-restore-helper:%%PKG_VERSION%%"/>
+            <label name="com.suse.reference" value="registry.suse.com/caasp/v4.5/velero-restic-restore-helper:%%PKG_VERSION%%"/>
           </suse_label_helper:add_prefix>
         </labels>
       </containerconfig>


### PR DESCRIPTION
Rename all the repo locations from v5 to v4.5

Related to SUSE/skuba#1294 and SUSE/avant-garde#1862