### PR TITLE
make image building reproducible

### DIFF
--- a/ci/packaging/suse/obsfiles_maker.sh
+++ b/ci/packaging/suse/obsfiles_maker.sh
@@ -4,12 +4,10 @@ set -e
 
 script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 image=$(basename "${1}")
-tmp_dir=$(mktemp -d -t "${image}_XXXX")
 obs_files="${script_dir}/obs_files/"
 
 log()   { (>&2 echo ">>> $*") ; }
-clean() { log "Cleaning temporary directory ${tmp_dir}"; rm -rf "${tmp_dir}"; }
-abort() { (>&2 echo ">>> $*") ; clean; exit 1;}
+abort() { (>&2 echo ">>> $*") ; exit 1;}
 
 [ $# -ne 1 ] && abort "missing image parameter"
 [ ! -d "${image}" ] && abort "Image directory ${image} not found"
@@ -19,14 +17,17 @@ trap clean ERR
 rm -rf "${obs_files}"
 mkdir -p "${obs_files}"
 
-cp "${image}/${image}.kiwi" "${tmp_dir}"
-[ -f "${image}/config.sh"  ] && cp "${image}/config.sh" "${tmp_dir}"
-[ -d "${image}/root"  ] && tar -caf "${tmp_dir}/root.tar.gz" \
-    -C "${image}/root" .
-[ -f "${image}/_service"  ] && cp "${image}/_service" "${tmp_dir}"
-make CHANGES="${tmp_dir}/${image}.changes.append" suse-changelog
+install -p -m 644 "${image}/${image}.kiwi" "${obs_files}"
+[ -f "${image}/config.sh"  ] && install -m 755 -p "${image}/config.sh" "${obs_files}"
+[ -f "${image}/_service"  ] && install -m 644 -p "${image}/_service" "${obs_files}"
 
-cp "${tmp_dir}"/* "${obs_files}"
+[ -d "${image}/root"  ] && \
+    tar --mtime=@1480000000 --owner=0 --group=0 --no-acls --no-xattrs \
+    --no-selinux --sort=name --numeric-owner \
+    --pax-option=exthdr.name=%d/PaxHeaders/%f,atime:=0,ctime:=0  \
+    --mode=a+X,u+r,ug-s,o-t -caf "${obs_files}/root.tar.gz" -C "${image}/root" .
+
+
+make CHANGES="${obs_files}/${image}.changes.append" suse-changelog
+
 log "Find files for RPM package in ${obs_files}"
-clean
-


### PR DESCRIPTION
The old scripts:
- used unnecessary copy into a temporary tempdir
- relied on system umask instead of using install(1)
- generated the root.tar.gz in a non-reproducible fashion

Fixes https://github.com/SUSE/avant-garde/issues/1770