### PR TITLE
Updated to rev3 to fetch correct cilium version for the image.

### DIFF
--- a/caasp-cilium-etcd-operator-image/caasp-cilium-etcd-operator-image.kiwi
+++ b/caasp-cilium-etcd-operator-image/caasp-cilium-etcd-operator-image.kiwi
@@ -32,7 +32,7 @@
         </labels>
       </containerconfig>
     </type>
-    <version>1</version>
+    <version>3</version>
     <packagemanager>zypper</packagemanager>
     <rpm-excludedocs>true</rpm-excludedocs>
   </preferences>

--- a/caasp-cilium-operator-image/caasp-cilium-operator-image.kiwi
+++ b/caasp-cilium-operator-image/caasp-cilium-operator-image.kiwi
@@ -33,7 +33,7 @@
         </labels>
       </containerconfig>
     </type>
-    <version>2</version>
+    <version>3</version>
     <packagemanager>zypper</packagemanager>
     <rpm-excludedocs>true</rpm-excludedocs>
   </preferences>


### PR DESCRIPTION
Cilium is updated to 1.7.6 along with updates for cilium-proxy and envoy-proxy to fix https://github.com/SUSE/avant-garde/issues/1865. 
The operator image should be built from the same version and a separation is required to identify the correct revision. The cilium image and the related images are hence updated to rev3. 