### PR TITLE
Change tiller image to use helm2 packaging

### DIFF
--- a/caasp-helm-tiller-image/_service
+++ b/caasp-helm-tiller-image/_service
@@ -3,7 +3,7 @@
         <param name="file">caasp-helm-tiller-image.kiwi</param>
         <param name="regex">%%PKG_VERSION%%</param>
         <param name="parse-version">patch</param>
-        <param name="package">helm</param>
+        <param name="package">helm2</param>
     </service>
     <service mode="buildtime" name="kiwi_metainfo_helper"/>
     <service mode="buildtime" name="kiwi_label_helper"/>

--- a/caasp-helm-tiller-image/caasp-helm-tiller-image.kiwi
+++ b/caasp-helm-tiller-image/caasp-helm-tiller-image.kiwi
@@ -33,7 +33,7 @@
         </labels>
       </containerconfig>
     </type>
-    <version>3</version>
+    <version>4</version>
     <packagemanager>zypper</packagemanager>
     <rpm-excludedocs>true</rpm-excludedocs>
   </preferences>
@@ -41,7 +41,7 @@
     <source path="obsrepositories:/"/>
   </repository>
   <packages type="image">
-    <package name="helm"/>
+    <package name="helm2"/>
     <package name="system-user-nobody"/>
   </packages>
 </image>


### PR DESCRIPTION
To facilitate moving to Helm 3 we changed the package naming.
"helm" package should now be "helm2".