### PR TITLE
Add the Jenkins pipeline

### DIFF
--- a/ci/jenkins/pipelines/caasp-container-images-automation.Jenkinsfile
+++ b/ci/jenkins/pipelines/caasp-container-images-automation.Jenkinsfile
@@ -1,0 +1,3 @@
+@Library('caasp-jenkins-lib@master') _
+ 
+containerImagesPR(env, 'containers-integration', 'master')


### PR DESCRIPTION
This commit adds a dummy jenkinsfile in order to pull the pipeline defined
in SUSE/caasp-automation repository.

~Note this PR can't be merged before SUSE/caasp-automation#783
and it still will require to be updated after that.~