### PR TITLE
Update reference label

### DIFF
--- a/caasp-389-ds-image/caasp-389-ds-image.kiwi
+++ b/caasp-389-ds-image/caasp-389-ds-image.kiwi
@@ -23,7 +23,7 @@
             <label name="org.opencontainers.image.url" value="https://www.suse.com/products/caas-platform/"/>
             <label name="org.opencontainers.image.version" value="%%PKG_VERSION%%"/>
             <label name="org.openbuildservice.disturl" value="%DISTURL%"/>
-            <label name="com.suse.reference" value="registry.suse.com/caasp/v4.5/389-ds:%%PKG_VERSION%%"/>
+            <label name="org.opensuse.reference" value="registry.suse.com/caasp/v4.5/389-ds:%%PKG_VERSION%%"/>
           </suse_label_helper:add_prefix>
         </labels>
         <expose>
@@ -37,7 +37,7 @@
         <subcommand clear="true"/>
       </containerconfig>
     </type>
-    <version>2</version>
+    <version>3</version>
     <packagemanager>zypper</packagemanager>
     <rpm-excludedocs>true</rpm-excludedocs>
   </preferences>

--- a/caasp-busybox-image/caasp-busybox-image.kiwi
+++ b/caasp-busybox-image/caasp-busybox-image.kiwi
@@ -28,12 +28,12 @@
             <label name="org.opencontainers.image.url" value="https://www.suse.com/products/caas-platform/"/>
             <label name="org.opencontainers.image.version" value="%%PKG_VERSION%%"/>
             <label name="org.openbuildservice.disturl" value="%DISTURL%"/>
-            <label name="com.suse.reference" value="registry.suse.com/caasp/v4.5/busybox:%%PKG_VERSION%%"/>
+            <label name="org.opensuse.reference" value="registry.suse.com/caasp/v4.5/busybox:%%PKG_VERSION%%"/>
           </suse_label_helper:add_prefix>
         </labels>
       </containerconfig>
     </type>
-    <version>1</version>
+    <version>2</version>
     <packagemanager>zypper</packagemanager>
     <rpm-excludedocs>true</rpm-excludedocs>
   </preferences>

--- a/caasp-caasp-dex-image/_constraints
+++ b/caasp-caasp-dex-image/_constraints
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<constraints>
+  <overwrite>
+    <conditions>
+      <arch>aarch64</arch>
+    </conditions>
+    <hardware>
+      <processors>4</processors>
+      <memory>
+        <size unit="M">16000</size>
+      </memory>
+    </hardware>
+  </overwrite>
+</constraints>

--- a/caasp-caasp-dex-image/caasp-caasp-dex-image.kiwi
+++ b/caasp-caasp-dex-image/caasp-caasp-dex-image.kiwi
@@ -27,12 +27,12 @@
             <label name="org.opencontainers.image.url" value="https://www.suse.com/products/caas-platform/"/>
             <label name="org.opencontainers.image.version" value="%%PKG_VERSION%%"/>
             <label name="org.openbuildservice.disturl" value="%DISTURL%"/>
-            <label name="com.suse.reference" value="registry.suse.com/caasp/v4.5/caasp-dex:%%PKG_VERSION%%"/>
+            <label name="org.opensuse.reference" value="registry.suse.com/caasp/v4.5/caasp-dex:%%PKG_VERSION%%"/>
           </suse_label_helper:add_prefix>
         </labels>
       </containerconfig> 
     </type>
-    <version>1</version>
+    <version>2</version>
     <packagemanager>zypper</packagemanager>
     <rpm-excludedocs>true</rpm-excludedocs>
   </preferences>

--- a/caasp-cert-exporter-image/caasp-cert-exporter-image.kiwi
+++ b/caasp-cert-exporter-image/caasp-cert-exporter-image.kiwi
@@ -28,12 +28,12 @@
             <label name="org.opencontainers.image.url" value="https://www.suse.com/products/caas-platform/"/>
             <label name="org.opencontainers.image.version" value="%%PKG_VERSION%%"/>
             <label name="org.openbuildservice.disturl" value="%DISTURL%"/>
-            <label name="com.suse.reference" value="registry.suse.com/caasp/v4.5/cert-exporter:%%PKG_VERSION%%"/>
+            <label name="org.opensuse.reference" value="registry.suse.com/caasp/v4.5/cert-exporter:%%PKG_VERSION%%"/>
           </suse_label_helper:add_prefix>
         </labels>
       </containerconfig>
     </type>
-    <version>1</version>
+    <version>2</version>
     <packagemanager>zypper</packagemanager>
     <rpm-excludedocs>true</rpm-excludedocs>
   </preferences>

--- a/caasp-cert-manager-cainjector-image/caasp-cert-manager-cainjector-image.kiwi
+++ b/caasp-cert-manager-cainjector-image/caasp-cert-manager-cainjector-image.kiwi
@@ -28,12 +28,12 @@
             <label name="org.opencontainers.image.url" value="https://www.suse.com/products/caas-platform/"/>
             <label name="org.opencontainers.image.version" value="%%PKG_VERSION%%"/>
             <label name="org.openbuildservice.disturl" value="%DISTURL%"/>
-            <label name="com.suse.reference" value="registry.suse.com/caasp/v4.5/cert-manager-cainjector:%%PKG_VERSION%%"/>
+            <label name="org.opensuse.reference" value="registry.suse.com/caasp/v4.5/cert-manager-cainjector:%%PKG_VERSION%%"/>
           </suse_label_helper:add_prefix>
         </labels>
       </containerconfig>
     </type>
-    <version>1</version>
+    <version>2</version>
     <packagemanager>zypper</packagemanager>
     <rpm-excludedocs>true</rpm-excludedocs>
   </preferences>

--- a/caasp-cert-manager-controller-image/caasp-cert-manager-controller-image.kiwi
+++ b/caasp-cert-manager-controller-image/caasp-cert-manager-controller-image.kiwi
@@ -28,12 +28,12 @@
             <label name="org.opencontainers.image.url" value="https://www.suse.com/products/caas-platform/"/>
             <label name="org.opencontainers.image.version" value="%%PKG_VERSION%%"/>
             <label name="org.openbuildservice.disturl" value="%DISTURL%"/>
-            <label name="com.suse.reference" value="registry.suse.com/caasp/v4.5/cert-manager-controller:%%PKG_VERSION%%"/>
+            <label name="org.opensuse.reference" value="registry.suse.com/caasp/v4.5/cert-manager-controller:%%PKG_VERSION%%"/>
           </suse_label_helper:add_prefix>
         </labels>
       </containerconfig>
     </type>
-    <version>1</version>
+    <version>2</version>
     <packagemanager>zypper</packagemanager>
     <rpm-excludedocs>true</rpm-excludedocs>
   </preferences>

--- a/caasp-cert-manager-webhook-image/caasp-cert-manager-webhook-image.kiwi
+++ b/caasp-cert-manager-webhook-image/caasp-cert-manager-webhook-image.kiwi
@@ -28,12 +28,12 @@
             <label name="org.opencontainers.image.url" value="https://www.suse.com/products/caas-platform/"/>
             <label name="org.opencontainers.image.version" value="%%PKG_VERSION%%"/>
             <label name="org.openbuildservice.disturl" value="%DISTURL%"/>
-            <label name="com.suse.reference" value="registry.suse.com/caasp/v4.5/cert-manager-webhook:%%PKG_VERSION%%"/>
+            <label name="org.opensuse.reference" value="registry.suse.com/caasp/v4.5/cert-manager-webhook:%%PKG_VERSION%%"/>
           </suse_label_helper:add_prefix>
         </labels>
       </containerconfig>
     </type>
-    <version>1</version>
+    <version>2</version>
     <packagemanager>zypper</packagemanager>
     <rpm-excludedocs>true</rpm-excludedocs>
   </preferences>

--- a/caasp-cilium-etcd-operator-image/caasp-cilium-etcd-operator-image.kiwi
+++ b/caasp-cilium-etcd-operator-image/caasp-cilium-etcd-operator-image.kiwi
@@ -27,12 +27,12 @@
             <label name="org.opencontainers.image.url" value="https://www.suse.com/products/caas-platform/"/>
             <label name="org.opencontainers.image.version" value="%%PKG_VERSION%%"/>
             <label name="org.openbuildservice.disturl" value="%DISTURL%"/>
-            <label name="com.suse.reference" value="registry.suse.com/caasp/v4.5/cilium-etcd-operator:%%PKG_VERSION%%"/>
+            <label name="org.opensuse.reference" value="registry.suse.com/caasp/v4.5/cilium-etcd-operator:%%PKG_VERSION%%"/>
           </suse_label_helper:add_prefix>
         </labels>
       </containerconfig>
     </type>
-    <version>3</version>
+    <version>4</version>
     <packagemanager>zypper</packagemanager>
     <rpm-excludedocs>true</rpm-excludedocs>
   </preferences>

--- a/caasp-cilium-image/_constraints
+++ b/caasp-cilium-image/_constraints
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<constraints>
+  <overwrite>
+    <conditions>
+      <arch>aarch64</arch>
+    </conditions>
+    <hardware>
+      <processors>4</processors>
+      <memory>
+        <size unit="M">16000</size>
+      </memory>
+    </hardware>
+  </overwrite>
+</constraints>

--- a/caasp-cilium-image/caasp-cilium-image.kiwi
+++ b/caasp-cilium-image/caasp-cilium-image.kiwi
@@ -27,12 +27,12 @@
             <label name="org.opencontainers.image.url" value="https://www.suse.com/products/caas-platform/"/>
             <label name="org.opencontainers.image.version" value="%%PKG_VERSION%%"/>
             <label name="org.openbuildservice.disturl" value="%DISTURL%"/>
-            <label name="com.suse.reference" value="registry.suse.com/caasp/v4.5/cilium:%%PKG_VERSION%%"/>
+            <label name="org.opensuse.reference" value="registry.suse.com/caasp/v4.5/cilium:%%PKG_VERSION%%"/>
           </suse_label_helper:add_prefix>
         </labels>
       </containerconfig>
     </type>
-    <version>3</version>
+    <version>4</version>
     <packagemanager>zypper</packagemanager>
     <rpm-excludedocs>true</rpm-excludedocs>
   </preferences>

--- a/caasp-cilium-operator-image/caasp-cilium-operator-image.kiwi
+++ b/caasp-cilium-operator-image/caasp-cilium-operator-image.kiwi
@@ -28,12 +28,12 @@
             <label name="org.opencontainers.image.url" value="https://www.suse.com/products/caas-platform/"/>
             <label name="org.opencontainers.image.version" value="%%PKG_VERSION%%"/>
             <label name="org.openbuildservice.disturl" value="%DISTURL%"/>
-            <label name="com.suse.reference" value="registry.suse.com/caasp/v4.5/cilium-operator:%%PKG_VERSION%%"/>
+            <label name="org.opensuse.reference" value="registry.suse.com/caasp/v4.5/cilium-operator:%%PKG_VERSION%%"/>
           </suse_label_helper:add_prefix>
         </labels>
       </containerconfig>
     </type>
-    <version>3</version>
+    <version>4</version>
     <packagemanager>zypper</packagemanager>
     <rpm-excludedocs>true</rpm-excludedocs>
   </preferences>

--- a/caasp-configmap-reload-image/caasp-configmap-reload-image.kiwi
+++ b/caasp-configmap-reload-image/caasp-configmap-reload-image.kiwi
@@ -27,12 +27,12 @@
             <label name="org.opencontainers.image.url" value="https://www.suse.com/products/caas-platform/"/>
             <label name="org.opencontainers.image.version" value="%%PKG_VERSION%%"/>
             <label name="org.openbuildservice.disturl" value="%DISTURL%"/>
-            <label name="com.suse.reference" value="registry.suse.com/caasp/v4.5/configmap-reload:%%PKG_VERSION%%"/>
+            <label name="org.opensuse.reference" value="registry.suse.com/caasp/v4.5/configmap-reload:%%PKG_VERSION%%"/>
           </suse_label_helper:add_prefix>
         </labels>
       </containerconfig>
     </type>
-    <version>1</version>
+    <version>2</version>
     <packagemanager>zypper</packagemanager>
     <rpm-excludedocs>true</rpm-excludedocs>
   </preferences>

--- a/caasp-coredns-image/caasp-coredns-image.kiwi
+++ b/caasp-coredns-image/caasp-coredns-image.kiwi
@@ -31,12 +31,12 @@
             <label name="org.opencontainers.image.url" value="https://www.suse.com/products/caas-platform/"/>
             <label name="org.opencontainers.image.version" value="%%PKG_VERSION%%"/>
             <label name="org.openbuildservice.disturl" value="%DISTURL%"/>
-            <label name="com.suse.reference" value="registry.suse.com/caasp/v4.5/coredns:%%PKG_VERSION%%"/>
+            <label name="org.opensuse.reference" value="registry.suse.com/caasp/v4.5/coredns:%%PKG_VERSION%%"/>
           </suse_label_helper:add_prefix>
         </labels>
       </containerconfig>
     </type>
-    <version>1</version>
+    <version>2</version>
     <packagemanager>zypper</packagemanager>
     <rpm-excludedocs>true</rpm-excludedocs>
   </preferences>

--- a/caasp-csi-attacher-image/Makefile
+++ b/caasp-csi-attacher-image/Makefile
@@ -1,0 +1,1 @@
+../.images.Makefile

--- a/caasp-csi-attacher-image/caasp-csi-attacher-image.kiwi
+++ b/caasp-csi-attacher-image/caasp-csi-attacher-image.kiwi
@@ -27,12 +27,12 @@
             <label name="org.opencontainers.image.url" value="https://www.suse.com/products/caas-platform/"/>
             <label name="org.opencontainers.image.version" value="v%%PKG_VERSION%%"/>
             <label name="org.openbuildservice.disturl" value="%DISTURL%"/>
-            <label name="com.suse.reference" value="registry.suse.com/caasp/v4.5/csi-attacher:v%%PKG_VERSION%%"/>
+            <label name="org.opensuse.reference" value="registry.suse.com/caasp/v4.5/csi-attacher:v%%PKG_VERSION%%"/>
           </suse_label_helper:add_prefix>
         </labels>
       </containerconfig>
     </type>
-    <version>1</version>
+    <version>2</version>
     <packagemanager>zypper</packagemanager>
     <rpm-excludedocs>true</rpm-excludedocs>
   </preferences>

--- a/caasp-csi-livenessprobe-image/Makefile
+++ b/caasp-csi-livenessprobe-image/Makefile
@@ -1,0 +1,1 @@
+../.images.Makefile

--- a/caasp-csi-livenessprobe-image/caasp-csi-livenessprobe-image.kiwi
+++ b/caasp-csi-livenessprobe-image/caasp-csi-livenessprobe-image.kiwi
@@ -27,12 +27,12 @@
             <label name="org.opencontainers.image.url" value="https://www.suse.com/products/caas-platform/"/>
             <label name="org.opencontainers.image.version" value="v%%PKG_VERSION%%"/>
             <label name="org.openbuildservice.disturl" value="%DISTURL%"/>
-            <label name="com.suse.reference" value="registry.suse.com/caasp/v4.5/csi-livenessprobe:v%%PKG_VERSION%%"/>
+            <label name="org.opensuse.reference" value="registry.suse.com/caasp/v4.5/csi-livenessprobe:v%%PKG_VERSION%%"/>
           </suse_label_helper:add_prefix>
         </labels>
       </containerconfig>
     </type>
-    <version>1</version>
+    <version>2</version>
     <packagemanager>zypper</packagemanager>
     <rpm-excludedocs>true</rpm-excludedocs>
   </preferences>

--- a/caasp-csi-node-driver-registrar-image/Makefile
+++ b/caasp-csi-node-driver-registrar-image/Makefile
@@ -1,0 +1,1 @@
+../.images.Makefile

--- a/caasp-csi-node-driver-registrar-image/caasp-csi-node-driver-registrar-image.kiwi
+++ b/caasp-csi-node-driver-registrar-image/caasp-csi-node-driver-registrar-image.kiwi
@@ -27,12 +27,12 @@
             <label name="org.opencontainers.image.url" value="https://www.suse.com/products/caas-platform/"/>
             <label name="org.opencontainers.image.version" value="v%%PKG_VERSION%%"/>
             <label name="org.openbuildservice.disturl" value="%DISTURL%"/>
-            <label name="com.suse.reference" value="registry.suse.com/caasp/v4.5/csi-node-driver-registrar:v%%PKG_VERSION%%"/>
+            <label name="org.opensuse.reference" value="registry.suse.com/caasp/v4.5/csi-node-driver-registrar:v%%PKG_VERSION%%"/>
           </suse_label_helper:add_prefix>
         </labels>
       </containerconfig>
     </type>
-    <version>1</version>
+    <version>2</version>
     <packagemanager>zypper</packagemanager>
     <rpm-excludedocs>true</rpm-excludedocs>
   </preferences>

--- a/caasp-csi-provisioner-image/Makefile
+++ b/caasp-csi-provisioner-image/Makefile
@@ -1,0 +1,1 @@
+../.images.Makefile

--- a/caasp-csi-provisioner-image/caasp-csi-provisioner-image.kiwi
+++ b/caasp-csi-provisioner-image/caasp-csi-provisioner-image.kiwi
@@ -27,12 +27,12 @@
             <label name="org.opencontainers.image.url" value="https://www.suse.com/products/caas-platform/"/>
             <label name="org.opencontainers.image.version" value="v%%PKG_VERSION%%"/>
             <label name="org.openbuildservice.disturl" value="%DISTURL%"/>
-            <label name="com.suse.reference" value="registry.suse.com/caasp/v4.5/csi-provisioner:v%%PKG_VERSION%%"/>
+            <label name="org.opensuse.reference" value="registry.suse.com/caasp/v4.5/csi-provisioner:v%%PKG_VERSION%%"/>
           </suse_label_helper:add_prefix>
         </labels>
       </containerconfig>
     </type>
-    <version>1</version>
+    <version>2</version>
     <packagemanager>zypper</packagemanager>
     <rpm-excludedocs>true</rpm-excludedocs>
   </preferences>

--- a/caasp-csi-resizer-image/Makefile
+++ b/caasp-csi-resizer-image/Makefile
@@ -1,0 +1,1 @@
+../.images.Makefile

--- a/caasp-csi-resizer-image/caasp-csi-resizer-image.kiwi
+++ b/caasp-csi-resizer-image/caasp-csi-resizer-image.kiwi
@@ -27,12 +27,12 @@
             <label name="org.opencontainers.image.url" value="https://www.suse.com/products/caas-platform/"/>
             <label name="org.opencontainers.image.version" value="v%%PKG_VERSION%%"/>
             <label name="org.openbuildservice.disturl" value="%DISTURL%"/>
-            <label name="com.suse.reference" value="registry.suse.com/caasp/v4.5/csi-resizer:v%%PKG_VERSION%%"/>
+            <label name="org.opensuse.reference" value="registry.suse.com/caasp/v4.5/csi-resizer:v%%PKG_VERSION%%"/>
           </suse_label_helper:add_prefix>
         </labels>
       </containerconfig>
     </type>
-    <version>1</version>
+    <version>2</version>
     <packagemanager>zypper</packagemanager>
     <rpm-excludedocs>true</rpm-excludedocs>
   </preferences>

--- a/caasp-csi-snapshotter-image/Makefile
+++ b/caasp-csi-snapshotter-image/Makefile
@@ -1,0 +1,1 @@
+../.images.Makefile

--- a/caasp-csi-snapshotter-image/caasp-csi-snapshotter-image.kiwi
+++ b/caasp-csi-snapshotter-image/caasp-csi-snapshotter-image.kiwi
@@ -27,12 +27,12 @@
             <label name="org.opencontainers.image.url" value="https://www.suse.com/products/caas-platform/"/>
             <label name="org.opencontainers.image.version" value="v%%PKG_VERSION%%"/>
             <label name="org.openbuildservice.disturl" value="%DISTURL%"/>
-            <label name="com.suse.reference" value="registry.suse.com/caasp/v4.5/csi-snapshotter:v%%PKG_VERSION%%"/>
+            <label name="org.opensuse.reference" value="registry.suse.com/caasp/v4.5/csi-snapshotter:v%%PKG_VERSION%%"/>
           </suse_label_helper:add_prefix>
         </labels>
       </containerconfig>
     </type>
-    <version>1</version>
+    <version>2</version>
     <packagemanager>zypper</packagemanager>
     <rpm-excludedocs>true</rpm-excludedocs>
   </preferences>

--- a/caasp-curl-image/caasp-curl-image.kiwi
+++ b/caasp-curl-image/caasp-curl-image.kiwi
@@ -28,12 +28,12 @@
             <label name="org.opencontainers.image.url" value="https://www.suse.com/products/caas-platform/"/>
             <label name="org.opencontainers.image.version" value="%%PKG_VERSION%%"/>
             <label name="org.openbuildservice.disturl" value="%DISTURL%"/>
-            <label name="com.suse.reference" value="registry.suse.com/caasp/v4.5/curl:%%PKG_VERSION%%"/>
+            <label name="org.opensuse.reference" value="registry.suse.com/caasp/v4.5/curl:%%PKG_VERSION%%"/>
           </suse_label_helper:add_prefix>
         </labels>
       </containerconfig>
     </type>
-    <version>1</version>
+    <version>2</version>
     <packagemanager>zypper</packagemanager>
     <rpm-excludedocs>true</rpm-excludedocs>
   </preferences>

--- a/caasp-default-http-backend-image/caasp-default-http-backend-image.kiwi
+++ b/caasp-default-http-backend-image/caasp-default-http-backend-image.kiwi
@@ -27,12 +27,12 @@
             <label name="org.opencontainers.image.url" value="https://www.suse.com/products/caas-platform/"/>
             <label name="org.opencontainers.image.version" value="%%PKG_VERSION%%"/>
             <label name="org.openbuildservice.disturl" value="%DISTURL%"/>
-            <label name="com.suse.reference" value="registry.suse.com/caasp/v4.5/default-http-backend:%%PKG_VERSION%%"/>
+            <label name="org.opensuse.reference" value="registry.suse.com/caasp/v4.5/default-http-backend:%%PKG_VERSION%%"/>
           </suse_label_helper:add_prefix>
         </labels>
       </containerconfig> 
     </type>
-    <version>1</version>
+    <version>2</version>
     <packagemanager>zypper</packagemanager>
     <rpm-excludedocs>true</rpm-excludedocs>
   </preferences>

--- a/caasp-etcd-image/caasp-etcd-image.kiwi
+++ b/caasp-etcd-image/caasp-etcd-image.kiwi
@@ -38,12 +38,12 @@
             <label name="org.opencontainers.image.url" value="https://www.suse.com/products/caas-platform/"/>
             <label name="org.opencontainers.image.version" value="%%PKG_VERSION%%"/>
             <label name="org.openbuildservice.disturl" value="%DISTURL%"/>
-            <label name="com.suse.reference" value="registry.suse.com/caasp/v4.5/etcd:%%PKG_VERSION%%"/>
+            <label name="org.opensuse.reference" value="registry.suse.com/caasp/v4.5/etcd:%%PKG_VERSION%%"/>
           </suse_label_helper:add_prefix>
         </labels>
       </containerconfig>
     </type>
-    <version>1</version>
+    <version>2</version>
     <packagemanager>zypper</packagemanager>
     <rpm-excludedocs>true</rpm-excludedocs>
   </preferences>

--- a/caasp-gangway-image/caasp-gangway-image.kiwi
+++ b/caasp-gangway-image/caasp-gangway-image.kiwi
@@ -27,12 +27,12 @@
             <label name="org.opencontainers.image.url" value="https://www.suse.com/products/caas-platform/"/>
             <label name="org.opencontainers.image.version" value="%%PKG_VERSION%%"/>
             <label name="org.openbuildservice.disturl" value="%DISTURL%"/>
-            <label name="com.suse.reference" value="registry.suse.com/caasp/v4.5/gangway:%%PKG_VERSION%%"/>
+            <label name="org.opensuse.reference" value="registry.suse.com/caasp/v4.5/gangway:%%PKG_VERSION%%"/>
           </suse_label_helper:add_prefix>
         </labels>
       </containerconfig>
     </type>
-    <version>5</version>
+    <version>6</version>
     <packagemanager>zypper</packagemanager>
     <rpm-excludedocs>true</rpm-excludedocs>
   </preferences>

--- a/caasp-grafana-image/caasp-grafana-image.kiwi
+++ b/caasp-grafana-image/caasp-grafana-image.kiwi
@@ -32,12 +32,12 @@
             <label name="org.opencontainers.image.url" value="https://www.suse.com/products/caas-platform/"/>
             <label name="org.opencontainers.image.version" value="%%PKG_VERSION%%"/>
             <label name="org.openbuildservice.disturl" value="%DISTURL%"/>
-            <label name="com.suse.reference" value="registry.suse.com/caasp/v4.5/grafana:%%PKG_VERSION%%"/>
+            <label name="org.opensuse.reference" value="registry.suse.com/caasp/v4.5/grafana:%%PKG_VERSION%%"/>
           </suse_label_helper:add_prefix>
         </labels>
       </containerconfig>
     </type>
-    <version>1</version>
+    <version>2</version>
     <packagemanager>zypper</packagemanager>
     <rpm-excludedocs>true</rpm-excludedocs>
   </preferences>

--- a/caasp-helm-tiller-image/caasp-helm-tiller-image.kiwi
+++ b/caasp-helm-tiller-image/caasp-helm-tiller-image.kiwi
@@ -28,12 +28,12 @@
             <label name="org.opencontainers.image.url" value="https://www.suse.com/products/caas-platform/"/>
             <label name="org.opencontainers.image.version" value="%%PKG_VERSION%%"/>
             <label name="org.openbuildservice.disturl" value="%DISTURL%"/>
-            <label name="com.suse.reference" value="registry.suse.com/caasp/v4.5/helm-tiller:%%PKG_VERSION%%"/>
+            <label name="org.opensuse.reference" value="registry.suse.com/caasp/v4.5/helm-tiller:%%PKG_VERSION%%"/>
           </suse_label_helper:add_prefix>
         </labels>
       </containerconfig>
     </type>
-    <version>1</version>
+    <version>2</version>
     <packagemanager>zypper</packagemanager>
     <rpm-excludedocs>true</rpm-excludedocs>
   </preferences>

--- a/caasp-ingress-nginx-controller-image/caasp-ingress-nginx-controller-image.kiwi
+++ b/caasp-ingress-nginx-controller-image/caasp-ingress-nginx-controller-image.kiwi
@@ -19,12 +19,12 @@
             <label name="org.opencontainers.image.url" value="https://www.suse.com/products/caas-platform/"/>
             <label name="org.opencontainers.image.version" value="%%PKG_VERSION%%"/>
             <label name="org.openbuildservice.disturl" value="%DISTURL%"/>
-            <label name="com.suse.reference" value="registry.suse.com/caasp/v4.5/ingress-nginx:%%PKG_VERSION%%"/>
+            <label name="org.opensuse.reference" value="registry.suse.com/caasp/v4.5/ingress-nginx:%%PKG_VERSION%%"/>
           </suse_label_helper:add_prefix>
         </labels>
       </containerconfig>
     </type>
-    <version>3</version>
+    <version>4</version>
     <packagemanager>zypper</packagemanager>
     <rpm-excludedocs>true</rpm-excludedocs>
   </preferences>

--- a/caasp-istio-base-image/caasp-istio-base-image.kiwi
+++ b/caasp-istio-base-image/caasp-istio-base-image.kiwi
@@ -27,12 +27,12 @@
             <label name="org.opencontainers.image.url" value="https://www.suse.com/products/caas-platform/"/>
             <label name="org.opencontainers.image.version" value="%%PKG_VERSION%%"/>
             <label name="org.openbuildservice.disturl" value="%DISTURL%"/>
-            <label name="com.suse.reference" value="registry.suse.com/caasp/v4.5/istio-base:%%PKG_VERSION%%"/>
+            <label name="org.opensuse.reference" value="registry.suse.com/caasp/v4.5/istio-base:%%PKG_VERSION%%"/>
           </suse_label_helper:add_prefix>
         </labels>
       </containerconfig>
     </type>
-    <version>4</version>
+    <version>5</version>
     <packagemanager>zypper</packagemanager>
     <rpm-excludedocs>true</rpm-excludedocs>
   </preferences>

--- a/caasp-istio-pilot-image/caasp-istio-pilot-image.kiwi
+++ b/caasp-istio-pilot-image/caasp-istio-pilot-image.kiwi
@@ -27,12 +27,12 @@
             <label name="org.opencontainers.image.url" value="https://www.suse.com/products/caas-platform/"/>
             <label name="org.opencontainers.image.version" value="%%PKG_VERSION%%"/>
             <label name="org.openbuildservice.disturl" value="%DISTURL%"/>
-            <label name="com.suse.reference" value="registry.suse.com/caasp/v4.5/istio-pilot:%%PKG_VERSION%%"/>
+            <label name="org.opensuse.reference" value="registry.suse.com/caasp/v4.5/istio-pilot:%%PKG_VERSION%%"/>
           </suse_label_helper:add_prefix>
         </labels>
       </containerconfig>
     </type>
-    <version>4</version>
+    <version>5</version>
     <packagemanager>zypper</packagemanager>
     <rpm-excludedocs>true</rpm-excludedocs>
   </preferences>

--- a/caasp-istio-proxyv2-image/caasp-istio-proxyv2-image.kiwi
+++ b/caasp-istio-proxyv2-image/caasp-istio-proxyv2-image.kiwi
@@ -27,7 +27,7 @@
             <label name="org.opencontainers.image.url" value="https://www.suse.com/products/caas-platform/"/>
             <label name="org.opencontainers.image.version" value="%%PKG_VERSION%%"/>
             <label name="org.openbuildservice.disturl" value="%DISTURL%"/>
-            <label name="com.suse.reference" value="registry.suse.com/caasp/v4.5/istio-proxyv2:%%PKG_VERSION%%"/>
+            <label name="org.opensuse.reference" value="registry.suse.com/caasp/v4.5/istio-proxyv2:%%PKG_VERSION%%"/>
           </suse_label_helper:add_prefix>
         </labels>
         <environment>
@@ -37,7 +37,7 @@
         </environment>	
       </containerconfig>
     </type>
-    <version>5</version>
+    <version>6</version>
     <packagemanager>zypper</packagemanager>
     <rpm-excludedocs>true</rpm-excludedocs>
   </preferences>

--- a/caasp-k8s-sidecar-image/caasp-k8s-sidecar-image.kiwi
+++ b/caasp-k8s-sidecar-image/caasp-k8s-sidecar-image.kiwi
@@ -32,12 +32,12 @@
             <label name="org.opencontainers.image.url" value="https://www.suse.com/products/caas-platform/"/>
             <label name="org.opencontainers.image.version" value="%%PKG_VERSION%%"/>
             <label name="org.openbuildservice.disturl" value="%DISTURL%"/>
-            <label name="com.suse.reference" value="registry.suse.com/caasp/v4.5/k8s-sidecar:%%PKG_VERSION%%"/>
+            <label name="org.opensuse.reference" value="registry.suse.com/caasp/v4.5/k8s-sidecar:%%PKG_VERSION%%"/>
           </suse_label_helper:add_prefix>
         </labels>
       </containerconfig>
     </type>
-    <version>1</version>
+    <version>2</version>
     <packagemanager>zypper</packagemanager>
     <rpm-excludedocs>true</rpm-excludedocs>
   </preferences>

--- a/caasp-kube-apiserver-image/caasp-kube-apiserver-image.kiwi
+++ b/caasp-kube-apiserver-image/caasp-kube-apiserver-image.kiwi
@@ -27,12 +27,12 @@
             <label name="org.opencontainers.image.url" value="https://www.suse.com/products/caas-platform/"/>
             <label name="org.opencontainers.image.version" value="%%PKG_VERSION%%"/>
             <label name="org.openbuildservice.disturl" value="%DISTURL%"/>
-            <label name="com.suse.reference" value="registry.suse.com/caasp/v4.5/kube-apiserver:v%%PKG_VERSION%%"/>
+            <label name="org.opensuse.reference" value="registry.suse.com/caasp/v4.5/kube-apiserver:v%%PKG_VERSION%%"/>
           </suse_label_helper:add_prefix>
         </labels>
       </containerconfig>
     </type>
-    <version>2</version>
+    <version>3</version>
     <packagemanager>zypper</packagemanager>
     <rpm-excludedocs>true</rpm-excludedocs>
   </preferences>

--- a/caasp-kube-controller-manager-image/caasp-kube-controller-manager-image.kiwi
+++ b/caasp-kube-controller-manager-image/caasp-kube-controller-manager-image.kiwi
@@ -27,12 +27,12 @@
             <label name="org.opencontainers.image.url" value="https://www.suse.com/products/caas-platform/"/>
             <label name="org.opencontainers.image.version" value="%%PKG_VERSION%%"/>
             <label name="org.openbuildservice.disturl" value="%DISTURL%"/>
-            <label name="com.suse.reference" value="registry.suse.com/caasp/v4.5/kube-controller-manager:v%%PKG_VERSION%%"/>
+            <label name="org.opensuse.reference" value="registry.suse.com/caasp/v4.5/kube-controller-manager:v%%PKG_VERSION%%"/>
           </suse_label_helper:add_prefix>
         </labels>
       </containerconfig>
     </type>
-    <version>2</version>
+    <version>3</version>
     <packagemanager>zypper</packagemanager>
     <rpm-excludedocs>true</rpm-excludedocs>
   </preferences>

--- a/caasp-kube-proxy-image/caasp-kube-proxy-image.kiwi
+++ b/caasp-kube-proxy-image/caasp-kube-proxy-image.kiwi
@@ -27,12 +27,12 @@
             <label name="org.opencontainers.image.url" value="https://www.suse.com/products/caas-platform/"/>
             <label name="org.opencontainers.image.version" value="%%PKG_VERSION%%"/>
             <label name="org.openbuildservice.disturl" value="%DISTURL%"/>
-            <label name="com.suse.reference" value="registry.suse.com/caasp/v4.5/kube-proxy:v%%PKG_VERSION%%"/>
+            <label name="org.opensuse.reference" value="registry.suse.com/caasp/v4.5/kube-proxy:v%%PKG_VERSION%%"/>
           </suse_label_helper:add_prefix>
         </labels>
       </containerconfig>
     </type>
-    <version>2</version>
+    <version>3</version>
     <packagemanager>zypper</packagemanager>
     <rpm-excludedocs>true</rpm-excludedocs>
   </preferences>

--- a/caasp-kube-scheduler-image/caasp-kube-scheduler-image.kiwi
+++ b/caasp-kube-scheduler-image/caasp-kube-scheduler-image.kiwi
@@ -27,12 +27,12 @@
             <label name="org.opencontainers.image.url" value="https://www.suse.com/products/caas-platform/"/>
             <label name="org.opencontainers.image.version" value="%%PKG_VERSION%%"/>
             <label name="org.openbuildservice.disturl" value="%DISTURL%"/>
-            <label name="com.suse.reference" value="registry.suse.com/caasp/v4.5/kube-scheduler:v%%PKG_VERSION%%"/>
+            <label name="org.opensuse.reference" value="registry.suse.com/caasp/v4.5/kube-scheduler:v%%PKG_VERSION%%"/>
           </suse_label_helper:add_prefix>
         </labels>
       </containerconfig>
     </type>
-    <version>2</version>
+    <version>3</version>
     <packagemanager>zypper</packagemanager>
     <rpm-excludedocs>true</rpm-excludedocs>
   </preferences>

--- a/caasp-kube-state-metrics-image/caasp-kube-state-metrics-image.kiwi
+++ b/caasp-kube-state-metrics-image/caasp-kube-state-metrics-image.kiwi
@@ -34,12 +34,12 @@
             <label name="org.opencontainers.image.url" value="https://www.suse.com/products/caas-platform/"/>
             <label name="org.opencontainers.image.version" value="%%PKG_VERSION%%"/>
             <label name="org.openbuildservice.disturl" value="%DISTURL%"/>
-            <label name="com.suse.reference" value="registry.suse.com/caasp/v4.5/kube-state-metrics:%%PKG_VERSION%%"/>
+            <label name="org.opensuse.reference" value="registry.suse.com/caasp/v4.5/kube-state-metrics:%%PKG_VERSION%%"/>
           </suse_label_helper:add_prefix>
         </labels>
       </containerconfig>
     </type>
-    <version>1</version>
+    <version>2</version>
     <packagemanager>zypper</packagemanager>
     <rpm-excludedocs>true</rpm-excludedocs>
   </preferences>

--- a/caasp-kubernetes-client-image/caasp-kubernetes-client-image.kiwi
+++ b/caasp-kubernetes-client-image/caasp-kubernetes-client-image.kiwi
@@ -27,12 +27,12 @@
             <label name="org.opencontainers.image.url" value="https://www.suse.com/products/caas-platform/"/>
             <label name="org.opencontainers.image.version" value="%%PKG_VERSION%%"/>
             <label name="org.openbuildservice.disturl" value="%DISTURL%"/>
-            <label name="com.suse.reference" value="registry.suse.com/caasp/v4.5/kubernetes-client:%%PKG_VERSION%%"/>
+            <label name="org.opensuse.reference" value="registry.suse.com/caasp/v4.5/kubernetes-client:%%PKG_VERSION%%"/>
           </suse_label_helper:add_prefix>
         </labels>
       </containerconfig>
     </type>
-    <version>3</version>
+    <version>4</version>
     <packagemanager>zypper</packagemanager>
     <rpm-excludedocs>true</rpm-excludedocs>
   </preferences>

--- a/caasp-kucero-image/caasp-kucero-image.kiwi
+++ b/caasp-kucero-image/caasp-kucero-image.kiwi
@@ -27,12 +27,12 @@
             <label name="org.opencontainers.image.url" value="https://www.suse.com/products/caas-platform/"/>
             <label name="org.opencontainers.image.version" value="%%PKG_VERSION%%"/>
             <label name="org.openbuildservice.disturl" value="%DISTURL%"/>
-            <label name="com.suse.reference" value="registry.suse.com/caasp/v4.5/kucero:%%PKG_VERSION%%"/>
+            <label name="org.opensuse.reference" value="registry.suse.com/caasp/v4.5/kucero:%%PKG_VERSION%%"/>
           </suse_label_helper:add_prefix>
         </labels>
       </containerconfig>
     </type>
-    <version>3</version>
+    <version>4</version>
     <packagemanager>zypper</packagemanager>
     <rpm-excludedocs>true</rpm-excludedocs>
   </preferences>

--- a/caasp-kured-image/caasp-kured-image.kiwi
+++ b/caasp-kured-image/caasp-kured-image.kiwi
@@ -27,12 +27,12 @@
             <label name="org.opencontainers.image.url" value="https://www.suse.com/products/caas-platform/"/>
             <label name="org.opencontainers.image.version" value="%%PKG_VERSION%%"/>
             <label name="org.openbuildservice.disturl" value="%DISTURL%"/>
-            <label name="com.suse.reference" value="registry.suse.com/caasp/v4.5/kured:%%PKG_VERSION%%"/>
+            <label name="org.opensuse.reference" value="registry.suse.com/caasp/v4.5/kured:%%PKG_VERSION%%"/>
           </suse_label_helper:add_prefix>
         </labels>
       </containerconfig>
     </type>
-    <version>3</version>
+    <version>4</version>
     <packagemanager>zypper</packagemanager>
     <rpm-excludedocs>true</rpm-excludedocs>
   </preferences>

--- a/caasp-metrics-server-image/caasp-metrics-server-image.kiwi
+++ b/caasp-metrics-server-image/caasp-metrics-server-image.kiwi
@@ -28,12 +28,12 @@
             <label name="org.opencontainers.image.url" value="https://www.suse.com/products/caas-platform/"/>
             <label name="org.opencontainers.image.version" value="%%PKG_VERSION%%"/>
             <label name="org.openbuildservice.disturl" value="%DISTURL%"/>
-            <label name="com.suse.reference" value="registry.suse.com/caasp/v4.5/metrics-server:%%PKG_VERSION%%"/>
+            <label name="org.opensuse.reference" value="registry.suse.com/caasp/v4.5/metrics-server:%%PKG_VERSION%%"/>
           </suse_label_helper:add_prefix>
         </labels>
       </containerconfig>
     </type>
-    <version>1</version>
+    <version>2</version>
     <packagemanager>zypper</packagemanager>
     <rpm-excludedocs>true</rpm-excludedocs>
   </preferences>

--- a/caasp-multus-image/caasp-multus-image.kiwi
+++ b/caasp-multus-image/caasp-multus-image.kiwi
@@ -27,12 +27,12 @@
             <label name="org.opencontainers.image.url" value="https://www.suse.com/products/caas-platform/"/>
             <label name="org.opencontainers.image.version" value="%%PKG_VERSION%%"/>
             <label name="org.openbuildservice.disturl" value="%DISTURL%"/>
-            <label name="com.suse.reference" value="registry.suse.com/caasp/v4.5/multus:%%PKG_VERSION%%"/>
+            <label name="org.opensuse.reference" value="registry.suse.com/caasp/v4.5/multus:%%PKG_VERSION%%"/>
           </suse_label_helper:add_prefix>
         </labels>
       </containerconfig>
     </type>
-    <version>1</version>
+    <version>2</version>
     <packagemanager>zypper</packagemanager>
     <rpm-excludedocs>true</rpm-excludedocs>
   </preferences>

--- a/caasp-pause-image/caasp-pause-image.kiwi
+++ b/caasp-pause-image/caasp-pause-image.kiwi
@@ -29,12 +29,12 @@
             <label name="org.opencontainers.image.url" value="https://www.suse.com/products/caas-platform/"/>
             <label name="org.opencontainers.image.version" value="3.2"/>
             <label name="org.openbuildservice.disturl" value="%DISTURL%"/>
-            <label name="com.suse.reference" value="registry.suse.com/caasp/v4.5/pause:3.2"/>
+            <label name="org.opensuse.reference" value="registry.suse.com/caasp/v4.5/pause:3.2"/>
           </suse_label_helper:add_prefix>
         </labels>
       </containerconfig>
     </type>
-    <version>2</version>
+    <version>3</version>
     <packagemanager>zypper</packagemanager>
     <rpm-excludedocs>true</rpm-excludedocs>
   </preferences>

--- a/caasp-prometheus-alertmanager-image/caasp-prometheus-alertmanager-image.kiwi
+++ b/caasp-prometheus-alertmanager-image/caasp-prometheus-alertmanager-image.kiwi
@@ -30,12 +30,12 @@
             <label name="org.opencontainers.image.url" value="https://www.suse.com/products/caas-platform/"/>
             <label name="org.opencontainers.image.version" value="%%PKG_VERSION%%"/>
             <label name="org.openbuildservice.disturl" value="%DISTURL%"/>
-            <label name="com.suse.reference" value="registry.suse.com/caasp/v4.5/prometheus-alertmanager:%%PKG_VERSION%%"/>
+            <label name="org.opensuse.reference" value="registry.suse.com/caasp/v4.5/prometheus-alertmanager:%%PKG_VERSION%%"/>
           </suse_label_helper:add_prefix>
         </labels>
       </containerconfig>
     </type>
-    <version>2</version>
+    <version>3</version>
     <packagemanager>zypper</packagemanager>
     <rpm-excludedocs>true</rpm-excludedocs>
   </preferences>

--- a/caasp-prometheus-node-exporter-image/caasp-prometheus-node-exporter-image.kiwi
+++ b/caasp-prometheus-node-exporter-image/caasp-prometheus-node-exporter-image.kiwi
@@ -32,12 +32,12 @@
             <label name="org.opencontainers.image.url" value="https://www.suse.com/products/caas-platform/"/>
             <label name="org.opencontainers.image.version" value="%%PKG_VERSION%%"/>
             <label name="org.openbuildservice.disturl" value="%DISTURL%"/>
-            <label name="com.suse.reference" value="registry.suse.com/caasp/v4.5/prometheus-node-exporter:%%PKG_VERSION%%"/>
+            <label name="org.opensuse.reference" value="registry.suse.com/caasp/v4.5/prometheus-node-exporter:%%PKG_VERSION%%"/>
           </suse_label_helper:add_prefix>
         </labels>
       </containerconfig>
     </type>
-    <version>2</version>
+    <version>3</version>
     <packagemanager>zypper</packagemanager>
     <rpm-excludedocs>true</rpm-excludedocs>
   </preferences>

--- a/caasp-prometheus-pushgateway-image/caasp-prometheus-pushgateway-image.kiwi
+++ b/caasp-prometheus-pushgateway-image/caasp-prometheus-pushgateway-image.kiwi
@@ -30,12 +30,12 @@
             <label name="org.opencontainers.image.url" value="https://www.suse.com/products/caas-platform/"/>
             <label name="org.opencontainers.image.version" value="%%PKG_VERSION%%"/>
             <label name="org.openbuildservice.disturl" value="%DISTURL%"/>
-            <label name="com.suse.reference" value="registry.suse.com/caasp/v4.5/prometheus-pushgateway:%%PKG_VERSION%%"/>
+            <label name="org.opensuse.reference" value="registry.suse.com/caasp/v4.5/prometheus-pushgateway:%%PKG_VERSION%%"/>
           </suse_label_helper:add_prefix>
         </labels>
       </containerconfig>
     </type>
-    <version>2</version>
+    <version>3</version>
     <packagemanager>zypper</packagemanager>
     <rpm-excludedocs>true</rpm-excludedocs>
   </preferences>

--- a/caasp-prometheus-server-image/caasp-prometheus-server-image.kiwi
+++ b/caasp-prometheus-server-image/caasp-prometheus-server-image.kiwi
@@ -30,12 +30,12 @@
             <label name="org.opencontainers.image.url" value="https://www.suse.com/products/caas-platform/"/>
             <label name="org.opencontainers.image.version" value="%%PKG_VERSION%%"/>
             <label name="org.openbuildservice.disturl" value="%DISTURL%"/>
-            <label name="com.suse.reference" value="registry.suse.com/caasp/v4.5/prometheus-server:%%PKG_VERSION%%"/>
+            <label name="org.opensuse.reference" value="registry.suse.com/caasp/v4.5/prometheus-server:%%PKG_VERSION%%"/>
           </suse_label_helper:add_prefix>
         </labels>
       </containerconfig>
     </type>
-    <version>2</version>
+    <version>3</version>
     <packagemanager>zypper</packagemanager>
     <rpm-excludedocs>true</rpm-excludedocs>
   </preferences>

--- a/caasp-reloader-image/caasp-reloader-image.kiwi
+++ b/caasp-reloader-image/caasp-reloader-image.kiwi
@@ -28,12 +28,12 @@
             <label name="org.opencontainers.image.url" value="https://www.suse.com/products/caas-platform/"/>
             <label name="org.opencontainers.image.version" value="%%PKG_VERSION%%"/>
             <label name="org.openbuildservice.disturl" value="%DISTURL%"/>
-            <label name="com.suse.reference" value="registry.suse.com/caasp/v4.5/reloader:%%PKG_VERSION%%"/>
+            <label name="org.opensuse.reference" value="registry.suse.com/caasp/v4.5/reloader:%%PKG_VERSION%%"/>
           </suse_label_helper:add_prefix>
         </labels>
       </containerconfig>
     </type>
-    <version>1</version>
+    <version>2</version>
     <packagemanager>zypper</packagemanager>
     <rpm-excludedocs>true</rpm-excludedocs>
   </preferences>

--- a/caasp-rsyslog-image/caasp-rsyslog-image.kiwi
+++ b/caasp-rsyslog-image/caasp-rsyslog-image.kiwi
@@ -29,12 +29,12 @@
             <label name="org.opencontainers.image.url" value="https://www.suse.com/products/caas-platform/"/>
             <label name="org.opencontainers.image.version" value="%%PKG_VERSION%%"/>
             <label name="org.openbuildservice.disturl" value="%DISTURL%"/>
-            <label name="com.suse.reference" value="registry.suse.com/caasp/v4.5/rsyslog:%%PKG_VERSION%%"/>
+            <label name="org.opensuse.reference" value="registry.suse.com/caasp/v4.5/rsyslog:%%PKG_VERSION%%"/>
           </suse_label_helper:add_prefix>
         </labels>
       </containerconfig>
     </type>
-    <version>1</version>
+    <version>2</version>
     <packagemanager>zypper</packagemanager>
     <rpm-excludedocs>true</rpm-excludedocs>
   </preferences>

--- a/caasp-skuba-tooling-image/_constraints
+++ b/caasp-skuba-tooling-image/_constraints
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<constraints>
+  <overwrite>
+    <conditions>
+      <arch>aarch64</arch>
+    </conditions>
+    <hardware>
+      <processors>4</processors>
+      <memory>
+        <size unit="M">16000</size>
+      </memory>
+    </hardware>
+  </overwrite>
+</constraints>

--- a/caasp-skuba-tooling-image/caasp-skuba-tooling-image.kiwi
+++ b/caasp-skuba-tooling-image/caasp-skuba-tooling-image.kiwi
@@ -25,12 +25,12 @@
             <label name="org.opencontainers.image.url" value="https://www.suse.com/products/caas-platform/"/>
             <label name="org.opencontainers.image.version" value="%%PKG_VERSION%%"/>
             <label name="org.openbuildservice.disturl" value="%DISTURL%"/>
-            <label name="com.suse.reference" value="registry.suse.com/caasp/v4.5/skuba-tooling:0.1.0"/>
+            <label name="org.opensuse.reference" value="registry.suse.com/caasp/v4.5/skuba-tooling:0.1.0"/>
           </suse_label_helper:add_prefix>
         </labels>
       </containerconfig>
     </type>
-    <version>1</version>
+    <version>2</version>
     <packagemanager>zypper</packagemanager>
     <rpm-excludedocs>true</rpm-excludedocs>
   </preferences>

--- a/caasp-velero-image/caasp-velero-image.kiwi
+++ b/caasp-velero-image/caasp-velero-image.kiwi
@@ -28,12 +28,12 @@
             <label name="org.opencontainers.image.url" value="https://www.suse.com/products/caas-platform/"/>
             <label name="org.opencontainers.image.version" value="%%PKG_VERSION%%"/>
             <label name="org.openbuildservice.disturl" value="%DISTURL%"/>
-            <label name="com.suse.reference" value="registry.suse.com/caasp/v4.5/velero:%%PKG_VERSION%%"/>
+            <label name="org.opensuse.reference" value="registry.suse.com/caasp/v4.5/velero:%%PKG_VERSION%%"/>
           </suse_label_helper:add_prefix>
         </labels>
       </containerconfig>
     </type>
-    <version>1</version>
+    <version>2</version>
     <packagemanager>zypper</packagemanager>
     <rpm-excludedocs>true</rpm-excludedocs>
   </preferences>

--- a/caasp-velero-plugin-for-aws-image/caasp-velero-plugin-for-aws-image.kiwi
+++ b/caasp-velero-plugin-for-aws-image/caasp-velero-plugin-for-aws-image.kiwi
@@ -31,12 +31,12 @@
             <label name="org.opencontainers.image.url" value="https://www.suse.com/products/caas-platform/"/>
             <label name="org.opencontainers.image.version" value="%%PKG_VERSION%%"/>
             <label name="org.openbuildservice.disturl" value="%DISTURL%"/>
-            <label name="com.suse.reference" value="registry.suse.com/caasp/v4.5/velero-plugin-for-aws:%%PKG_VERSION%%"/>
+            <label name="org.opensuse.reference" value="registry.suse.com/caasp/v4.5/velero-plugin-for-aws:%%PKG_VERSION%%"/>
           </suse_label_helper:add_prefix>
         </labels>
       </containerconfig>
     </type>
-    <version>1</version>
+    <version>2</version>
     <packagemanager>zypper</packagemanager>
     <rpm-excludedocs>true</rpm-excludedocs>
   </preferences>

--- a/caasp-velero-plugin-for-gcp-image/_constraints
+++ b/caasp-velero-plugin-for-gcp-image/_constraints
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<constraints>
+  <overwrite>
+    <conditions>
+      <arch>aarch64</arch>
+    </conditions>
+    <hardware>
+      <processors>4</processors>
+      <memory>
+        <size unit="M">16000</size>
+      </memory>
+    </hardware>
+  </overwrite>
+</constraints>

--- a/caasp-velero-plugin-for-gcp-image/caasp-velero-plugin-for-gcp-image.kiwi
+++ b/caasp-velero-plugin-for-gcp-image/caasp-velero-plugin-for-gcp-image.kiwi
@@ -30,12 +30,12 @@
             <label name="org.opencontainers.image.url" value="https://www.suse.com/products/caas-platform/"/>
             <label name="org.opencontainers.image.version" value="%%PKG_VERSION%%"/>
             <label name="org.openbuildservice.disturl" value="%DISTURL%"/>
-            <label name="com.suse.reference" value="registry.suse.com/caasp/v4.5/velero-plugin-for-gcp:%%PKG_VERSION%%"/>
+            <label name="org.opensuse.reference" value="registry.suse.com/caasp/v4.5/velero-plugin-for-gcp:%%PKG_VERSION%%"/>
           </suse_label_helper:add_prefix>
         </labels>
       </containerconfig>
     </type>
-    <version>1</version>
+    <version>2</version>
     <packagemanager>zypper</packagemanager>
     <rpm-excludedocs>true</rpm-excludedocs>
   </preferences>

--- a/caasp-velero-plugin-for-microsoft-azure-image/caasp-velero-plugin-for-microsoft-azure-image.kiwi
+++ b/caasp-velero-plugin-for-microsoft-azure-image/caasp-velero-plugin-for-microsoft-azure-image.kiwi
@@ -31,12 +31,12 @@
             <label name="org.opencontainers.image.url" value="https://www.suse.com/products/caas-platform/"/>
             <label name="org.opencontainers.image.version" value="%%PKG_VERSION%%"/>
             <label name="org.openbuildservice.disturl" value="%DISTURL%"/>
-            <label name="com.suse.reference" value="registry.suse.com/caasp/v4.5/velero-plugin-for-microsoft-azure:%%PKG_VERSION%%"/>
+            <label name="org.opensuse.reference" value="registry.suse.com/caasp/v4.5/velero-plugin-for-microsoft-azure:%%PKG_VERSION%%"/>
           </suse_label_helper:add_prefix>
         </labels>
       </containerconfig>
     </type>
-    <version>1</version>
+    <version>2</version>
     <packagemanager>zypper</packagemanager>
     <rpm-excludedocs>true</rpm-excludedocs>
   </preferences>

--- a/caasp-velero-restic-restore-helper-image/caasp-velero-restic-restore-helper-image.kiwi
+++ b/caasp-velero-restic-restore-helper-image/caasp-velero-restic-restore-helper-image.kiwi
@@ -28,12 +28,12 @@
             <label name="org.opencontainers.image.url" value="https://www.suse.com/products/caas-platform/"/>
             <label name="org.opencontainers.image.version" value="%%PKG_VERSION%%"/>
             <label name="org.openbuildservice.disturl" value="%DISTURL%"/>
-            <label name="com.suse.reference" value="registry.suse.com/caasp/v4.5/velero-restic-restore-helper:%%PKG_VERSION%%"/>
+            <label name="org.opensuse.reference" value="registry.suse.com/caasp/v4.5/velero-restic-restore-helper:%%PKG_VERSION%%"/>
           </suse_label_helper:add_prefix>
         </labels>
       </containerconfig>
     </type>
-    <version>1</version>
+    <version>2</version>
     <packagemanager>zypper</packagemanager>
     <rpm-excludedocs>true</rpm-excludedocs>
   </preferences>

--- a/ci/packaging/suse/obsfiles_maker.sh
+++ b/ci/packaging/suse/obsfiles_maker.sh
@@ -20,6 +20,7 @@ mkdir -p "${obs_files}"
 install -p -m 644 "${image}/${image}.kiwi" "${obs_files}"
 [ -f "${image}/config.sh"  ] && install -m 755 -p "${image}/config.sh" "${obs_files}"
 [ -f "${image}/_service"  ] && install -m 644 -p "${image}/_service" "${obs_files}"
+[ -f "${image}/_constraints"  ] && install -m 644 -p "${image}/_constraints" "${obs_files}"
 
 [ -d "${image}/root"  ] && \
     tar --mtime=@1480000000 --owner=0 --group=0 --no-acls --no-xattrs \


### PR DESCRIPTION
This commit updates the reference label to match SUSE's labelling criteria.

Fixes SUSE/avant-garde#1956