### PR TITLE
Bump caasp-cilium-image version to include bpftool update (bsc#1177348)

### DIFF
--- a/caasp-cilium-image/caasp-cilium-image.kiwi
+++ b/caasp-cilium-image/caasp-cilium-image.kiwi
@@ -32,7 +32,7 @@
         </labels>
       </containerconfig>
     </type>
-    <version>4</version>
+    <version>5</version>
     <packagemanager>zypper</packagemanager>
     <rpm-excludedocs>true</rpm-excludedocs>
   </preferences>


### PR DESCRIPTION
This PR just bumps the version number of the cilium image. This way we can refer to the new image in versions.go to ensure the image is updated and contains the patched bpftool package.