### PR TITLE
Bump revision version to match caasp-cilium-image

### DIFF
--- a/caasp-cilium-operator-image/caasp-cilium-operator-image.kiwi
+++ b/caasp-cilium-operator-image/caasp-cilium-operator-image.kiwi
@@ -15,7 +15,7 @@
       <containerconfig
         name="caasp/v4.5/cilium-operator"
         tag="%%PKG_VERSION%%"
-	    maintainer="SUSE Containers Team &lt;containers@suse.com&gt;">
+        maintainer="SUSE Containers Team &lt;containers@suse.com&gt;">
         <entrypoint execute="/usr/bin/cilium-operator"/>
         <subcommand clear="true"/>
         <history author="Nirmoy Das &lt;ndas@suse.de&gt;">cilium-operator Container</history>
@@ -33,7 +33,7 @@
         </labels>
       </containerconfig>
     </type>
-    <version>4</version>
+    <version>5</version>
     <packagemanager>zypper</packagemanager>
     <rpm-excludedocs>true</rpm-excludedocs>
   </preferences>


### PR DESCRIPTION
The reference of caasp-cilium-operator-image uses the same tag as for
the image caasp-cilium-image. Both images need to be aligned with the
same revision.